### PR TITLE
Restore main window position

### DIFF
--- a/src/main/app_setting.ts
+++ b/src/main/app_setting.ts
@@ -1,0 +1,128 @@
+import { app, BrowserWindow, Rectangle, screen } from 'electron'
+import * as fs from 'fs'
+import path from 'node:path'
+
+interface StoredMainWindowBounds {
+  readonly x: number
+  readonly y: number
+  readonly width: number
+  readonly height: number
+}
+
+interface AppJsonSetting {
+  window?: {
+    main?: StoredMainWindowBounds
+  }
+}
+
+const appJsonPath = (): string => path.join(app.getPath('userData'), 'koubrowser.json')
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function isFiniteNumber(value: unknown): value is number {
+  return typeof value === 'number' && Number.isFinite(value)
+}
+
+function readAppJsonSetting(): AppJsonSetting {
+  const filepath = appJsonPath()
+  if (!fs.existsSync(filepath)) {
+    return {}
+  }
+
+  try {
+    const parsed = JSON.parse(fs.readFileSync(filepath, 'utf8'))
+    return isPlainObject(parsed) ? parsed : {}
+  } catch (err: unknown) {
+    console.error(err)
+    return {}
+  }
+}
+
+function writeAppJsonSetting(setting: AppJsonSetting): void {
+  try {
+    fs.writeFileSync(appJsonPath(), JSON.stringify(setting, undefined, ' '), 'utf8')
+  } catch (err: unknown) {
+    console.error(err)
+  }
+}
+
+function isStoredMainWindowBounds(value: unknown): value is StoredMainWindowBounds {
+  if (!isPlainObject(value)) {
+    return false
+  }
+
+  return (
+    isFiniteNumber(value.x) &&
+    isFiniteNumber(value.y) &&
+    isFiniteNumber(value.width) &&
+    isFiniteNumber(value.height) &&
+    value.width > 0 &&
+    value.height > 0
+  )
+}
+
+function isPositionInBounds(position: { x: number; y: number }, bounds: Rectangle): boolean {
+  return (
+    position.x >= bounds.x &&
+    position.y >= bounds.y &&
+    position.x < bounds.x + bounds.width &&
+    position.y < bounds.y + bounds.height
+  )
+}
+
+function getAllDisplayBounds(): Rectangle | undefined {
+  const displays = screen.getAllDisplays()
+  if (displays.length === 0) {
+    return undefined
+  }
+
+  const minX = Math.min(...displays.map((display) => display.bounds.x))
+  const minY = Math.min(...displays.map((display) => display.bounds.y))
+  const maxX = Math.max(...displays.map((display) => display.bounds.x + display.bounds.width))
+  const maxY = Math.max(...displays.map((display) => display.bounds.y + display.bounds.height))
+  return {
+    x: minX,
+    y: minY,
+    width: maxX - minX,
+    height: maxY - minY
+  }
+}
+
+export function restoreMainWindowPosition(): { x: number; y: number } | undefined {
+  const savedBounds = readAppJsonSetting().window?.main
+  if (!isStoredMainWindowBounds(savedBounds)) {
+    return undefined
+  }
+
+  const displayBounds = getAllDisplayBounds()
+  //console.log('Saved main window bounds:', savedBounds, 'all Display bounds:', displayBounds)
+  if (!displayBounds || !isPositionInBounds(savedBounds, displayBounds)) {
+    //console.warn('Saved main window position is out of display bounds. Using default position.')
+    return undefined
+  }
+
+  return { x: savedBounds.x, y: savedBounds.y }
+}
+
+export function saveMainWindowPosition(window: BrowserWindow): void {
+  if (window.isDestroyed()) {
+    return
+  }
+
+  const bounds = window.getBounds()
+  const setting = readAppJsonSetting()
+  const windowSetting = isPlainObject(setting.window) ? setting.window : {}
+  setting.window = {
+    ...windowSetting,
+    main: {
+      x: bounds.x,
+      y: bounds.y,
+      width: bounds.width,
+      height: bounds.height
+    }
+  }
+
+  writeAppJsonSetting(setting)
+}

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -84,6 +84,7 @@ app.on('before-quit', async (event) => {
     beforeQuitHandled = true
     const kcapp = getKcApp()
     if (kcapp) {
+      kcapp.saveMainWindowPosition()
       event.preventDefault()
       try {
         console.time('intakedrop and shutdown worker driver tid:'+ threadId)

--- a/src/main/kcbrowser.ts
+++ b/src/main/kcbrowser.ts
@@ -63,6 +63,7 @@ import { AggregatedCellRank, AggregatedCellShipDrop } from '@common/calc_record'
 import { Intaker } from '@main/stuff/intaker'
 import { setTestData } from '@main/debug-data'
 import { UpdateCheckResult, UpdateStateSnapshot } from '@common/type'
+import { restoreMainWindowPosition, saveMainWindowPosition } from '@main/app_setting'
 
 /////////////////////////////////////////////////////////////////////////////////////
 // debug
@@ -71,8 +72,6 @@ const DEBUG = false;
 const debug = (...args: any[]) => {
   if (DEBUG) console.info("[KcBrowser]", ...args);
 };
-
-/////////////////////////////////////////////////////////////////////////////////////
 
 
 const setUseragent = (): void => {
@@ -202,6 +201,10 @@ export class KcApp {
     return this.assist_window
   }
 
+  public saveMainWindowPosition(): void {
+    saveMainWindowPosition(this.mainWindow)
+  }
+
   constructor() { 
     kcapp = this
 
@@ -223,9 +226,9 @@ export class KcApp {
     // Create the browser window.
     const withAssistSize = calcAssistWindowSize()
     const gameOnlySize = calcGameOnlySize()
+    const mainWindowPosition = restoreMainWindowPosition()
+    const mainWindowPlacement = mainWindowPosition ?? { center: true }
 
-    const x = 20
-    const y = 40
     this.frame_ratio = AppStuff.calcFrameRatio(gameOnlySize.width, gameOnlySize.height)
     const minWidth = 600
     const minHeight = AppStuff.calcFrameHeight(this.frame_ratio, minWidth)
@@ -350,12 +353,11 @@ export class KcApp {
     if (Env.isTestMode) {
       additionalArguments.push(Const.ArgIsTestMode);
     }
-    this.main_window = new BrowserWindow({
+    const mainWindowOptions: BrowserWindowConstructorOptions = {
       useContentSize: true,
       width: withAssistSize.width,
       height: withAssistSize.height,
-      x: x,
-      y: y,
+      ...mainWindowPlacement,
       minWidth: minWidth,
       minHeight: minHeight,
       fullscreenable: false,
@@ -375,7 +377,8 @@ export class KcApp {
         sandbox: false
         //sandbox: true
       }
-    })
+    }
+    this.main_window = new BrowserWindow(mainWindowOptions)
 
     this.main_window.webContents.on('will-attach-webview', (_event, webPreferences, params) => {
       debug('will-attach-webview:', params, webPreferences)
@@ -416,6 +419,7 @@ export class KcApp {
     // open app html
     openAppHtml(this.mainWindow)
 
+    this.mainWindow.on('close', () => this.saveMainWindowPosition())
     this.mainWindow.on('closed', () => this.onClosed())
     this.mainWindow.on('resize', () => this.onResize())
     this.mainWindow.on('will-resize', (event, newBounds, _details) =>
@@ -720,6 +724,7 @@ export class KcApp {
    */
   private async onChannelClose() {
     debug('on channel msg', MainChannel.close)
+    this.saveMainWindowPosition()
     // no effect
     //mainWindow.close();
     this.mainWindow.destroy()


### PR DESCRIPTION
## Summary
- Save the main window position to `koubrowser.json` under Electron `userData`
- Restore the saved position on startup when it is within the combined display bounds
- Center the window when no valid saved position is available

## Validation
- `npm run typecheck`
- `npx eslint src/main/app_setting.ts`

Closes #2