### PR TITLE
Persist game-only window state

### DIFF
--- a/src/main/app_setting.ts
+++ b/src/main/app_setting.ts
@@ -11,11 +11,16 @@ interface StoredMainWindowBounds {
 
 interface AppJsonSetting {
   window?: {
+    assist_in_game?: boolean
+    game_only_width?: number
+    game_only_height?: number
     main?: StoredMainWindowBounds
+    gameOnly?: StoredMainWindowBounds
   }
 }
 
 const appJsonPath = (): string => path.join(app.getPath('userData'), 'koubrowser.json')
+let appJsonSetting: AppJsonSetting | null = null
 
 function isPlainObject(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value)
@@ -40,7 +45,21 @@ function readAppJsonSetting(): AppJsonSetting {
   }
 }
 
+export function loadAppJsonSetting(): void {
+  if (appJsonSetting !== null) {
+    return
+  }
+
+  appJsonSetting = readAppJsonSetting()
+}
+
+function getAppJsonSetting(): AppJsonSetting {
+  loadAppJsonSetting()
+  return appJsonSetting ?? {}
+}
+
 function writeAppJsonSetting(setting: AppJsonSetting): void {
+  appJsonSetting = setting
   try {
     fs.writeFileSync(appJsonPath(), JSON.stringify(setting, undefined, ' '), 'utf8')
   } catch (err: unknown) {
@@ -76,8 +95,7 @@ function isPositionInAnyDisplay(position: { x: number; y: number }): boolean {
   return screen.getAllDisplays().some((display) => isPositionInBounds(position, display.bounds))
 }
 
-export function restoreMainWindowPosition(): { x: number; y: number } | undefined {
-  const savedBounds = readAppJsonSetting().window?.main
+function restoreWindowBounds(savedBounds: unknown): StoredMainWindowBounds | undefined {
   if (!isStoredMainWindowBounds(savedBounds)) {
     return undefined
   }
@@ -87,20 +105,49 @@ export function restoreMainWindowPosition(): { x: number; y: number } | undefine
     return undefined
   }
 
-  return { x: savedBounds.x, y: savedBounds.y }
+  return savedBounds
 }
 
-export function saveMainWindowPosition(window: BrowserWindow): void {
+export function restoreAssistInGame(): boolean | undefined {
+  const assistInGame = getAppJsonSetting().window?.assist_in_game
+  return typeof assistInGame === 'boolean' ? assistInGame : undefined
+}
+
+export function restoreMainWindowBounds(assistInGame: boolean): StoredMainWindowBounds | undefined {
+  const windowSetting = getAppJsonSetting().window
+  const savedBounds = assistInGame ? windowSetting?.main : windowSetting?.gameOnly
+  return restoreWindowBounds(savedBounds)
+}
+
+export function restoreGameOnlySize(): { width: number; height: number } | undefined {
+  const windowSetting = getAppJsonSetting().window
+  const width = windowSetting?.game_only_width
+  const height = windowSetting?.game_only_height
+  if (!isFiniteNumber(width) || !isFiniteNumber(height) || width <= 0 || height <= 0) {
+    return undefined
+  }
+
+  return { width, height }
+}
+
+export function saveMainWindowPosition(
+  window: BrowserWindow,
+  assistInGame: boolean,
+  gameOnlySize: { width: number; height: number }
+): void {
   if (window.isDestroyed()) {
     return
   }
 
   const bounds = window.getBounds()
-  const setting = readAppJsonSetting()
+  const setting = getAppJsonSetting()
   const windowSetting = isPlainObject(setting.window) ? setting.window : {}
   setting.window = {
     ...windowSetting,
-    main: {
+    assist_in_game: assistInGame,
+    game_only_width: gameOnlySize.width,
+    game_only_height: gameOnlySize.height,
+    [assistInGame ? 'main' : 'gameOnly']: {
       x: bounds.x,
       y: bounds.y,
       width: bounds.width,

--- a/src/main/kcbrowser.ts
+++ b/src/main/kcbrowser.ts
@@ -63,7 +63,7 @@ import { AggregatedCellRank, AggregatedCellShipDrop } from '@common/calc_record'
 import { Intaker } from '@main/stuff/intaker'
 import { setTestData } from '@main/debug-data'
 import { UpdateCheckResult, UpdateStateSnapshot } from '@common/type'
-import { restoreMainWindowPosition, saveMainWindowPosition } from '@main/app_setting'
+import { loadAppJsonSetting, restoreAssistInGame, restoreGameOnlySize, restoreMainWindowBounds, saveMainWindowPosition } from '@main/app_setting'
 
 /////////////////////////////////////////////////////////////////////////////////////
 // debug
@@ -202,7 +202,10 @@ export class KcApp {
   }
 
   public saveMainWindowPosition(): void {
-    saveMainWindowPosition(this.mainWindow)
+    saveMainWindowPosition(this.mainWindow, gameSetting.assistInGame, {
+      width: appState.game_only_width,
+      height: appState.game_only_height
+    })
   }
 
   constructor() { 
@@ -216,6 +219,7 @@ export class KcApp {
 
     // set user data dir
     setUserDataDir(app.getPath('userData'))
+    loadAppJsonSetting()
 
     // check assist stuff
     gameSetting.assist_ok = screen
@@ -223,10 +227,19 @@ export class KcApp {
       .some((el) => el.bounds.height >= 960 && el.bounds.width >= 1800)
     //screen.getAllDisplays().forEach(el => console.log(el));
 
+    const restoredAssistInGame = restoreAssistInGame()
+    if (restoredAssistInGame !== undefined) {
+      gameSetting.setAssistInGame(restoredAssistInGame)
+    }
+    const restoredGameOnlySize = restoreGameOnlySize()
+
     // Create the browser window.
-    const withAssistSize = calcAssistWindowSize()
+    const restoredMainWindowBounds = restoreMainWindowBounds(gameSetting.isAssistInGame)
+    const withAssistSize = restoredMainWindowBounds ?? calcAssistWindowSize()
     const gameOnlySize = calcGameOnlySize()
-    const mainWindowPosition = restoreMainWindowPosition()
+    const mainWindowPosition = restoredMainWindowBounds
+      ? { x: restoredMainWindowBounds.x, y: restoredMainWindowBounds.y }
+      : undefined
     const mainWindowPlacement = mainWindowPosition ?? { center: true }
 
     this.frame_ratio = AppStuff.calcFrameRatio(gameOnlySize.width, gameOnlySize.height)
@@ -379,6 +392,10 @@ export class KcApp {
       }
     }
     this.main_window = new BrowserWindow(mainWindowOptions)
+    if (restoredGameOnlySize) {
+      appState.game_only_width = restoredGameOnlySize.width
+      appState.game_only_height = restoredGameOnlySize.height
+    }
 
     this.main_window.webContents.on('will-attach-webview', (_event, webPreferences, params) => {
       debug('will-attach-webview:', params, webPreferences)
@@ -404,6 +421,9 @@ export class KcApp {
     )
 
     gameSettingProxy.webContents = this.main_window.webContents
+    if (!gameSetting.isAssistInGame) {
+      this.updateGameOnlyZoomFactor()
+    }
     this.main_window.setAlwaysOnTop(gameSetting.topmost)
 
     debug(
@@ -669,6 +689,21 @@ export class KcApp {
       gameSetting.zoom_factor = AppStuff.calcGameZoomFactor(size.width)
     }
     this.nohandle_resize = false
+  }
+
+  /**
+   *
+   */
+  private updateGameOnlyZoomFactor(): void {
+    if (gameSetting.isAssistInGame) {
+      return
+    }
+
+    const size = this.mainWindow.getContentSize()
+    appState.game_only_width = size[0]
+    appState.game_only_height = size[1]
+    const calcSize = calcAssistWindowSize()
+    gameSetting.zoom_factor = AppStuff.calcGameZoomFactor(calcSize.width)
   }
 
   /**


### PR DESCRIPTION
## Summary
- Save assist_in_game and game-only window state to koubrowser.json
- Restore gameOnly bounds when assist_in_game is false
- Restore appState game_only_width and game_only_height after creating the main window

## Validation
- npm run typecheck
- npx eslint src/main/app_setting.ts