### PR TITLE
[codex] Persist app window state

### DIFF
--- a/src/common/channel.ts
+++ b/src/common/channel.ts
@@ -13,6 +13,7 @@ export const MainChannel = {
   save_capture: 'save_capture',
   openAssist: 'openAssist',
   topmost: 'topmost',
+  notify_mute_state: 'notify_mute_state',
   refresh_assist: 'refresh_assist',
   store_rec: 'store-rec',
   request_required_data: 'request_required_data',

--- a/src/common/const.ts
+++ b/src/common/const.ts
@@ -25,5 +25,6 @@ export class Const {
   public static readonly AppUserModelId = 'com.koubrowser.app'
   public static readonly ArgIsAssist = '--is-assist'
   public static readonly ArgIsTestMode = '--is-test-mode'
+  public static readonly ArgIsInitMuted = '--is-init-muted'
   public static readonly GamePageUrl = 'https://www.dmm.com/netgame/feature/kancolle.html'
 }

--- a/src/main/__tests__/app_setting.test.ts
+++ b/src/main/__tests__/app_setting.test.ts
@@ -43,6 +43,8 @@ const originalSetting = {
     },
     game_only_width: 1541,
     game_only_height: 1007,
+    topmost: true,
+    muted: true,
     abc: 10,
     aaa: 0,
     anyobj: {
@@ -91,8 +93,10 @@ describe('app_setting', () => {
       width: 1541,
       height: 1007
     })
+    expect(appSetting.restoreTopmost()).toBe(true)
+    expect(appSetting.restoreMuted()).toBe(true)
 
-    appSetting.saveMainWindowPosition(
+    appSetting.saveAppState(
       {
         isDestroyed: () => false,
         getBounds: () => ({
@@ -106,7 +110,9 @@ describe('app_setting', () => {
       {
         width: 1200,
         height: 900
-      }
+      },
+      false,
+      false
     )
 
     const saved = JSON.parse(
@@ -118,6 +124,8 @@ describe('app_setting', () => {
     expect(saved.window.anyobj).toEqual({ key1: 100 })
     expect(saved.window.main).toEqual(originalSetting.window.main)
     expect(saved.window.assist_in_game).toBe(false)
+    expect(saved.window.topmost).toBe(false)
+    expect(saved.window.muted).toBe(false)
     expect(saved.window.game_only_width).toBe(1200)
     expect(saved.window.game_only_height).toBe(900)
     expect(saved.window.gameOnly).toEqual({

--- a/src/main/app_setting.ts
+++ b/src/main/app_setting.ts
@@ -12,6 +12,8 @@ interface StoredMainWindowBounds {
 interface AppJsonSetting {
   window?: {
     assist_in_game?: boolean
+    topmost?: boolean
+    muted?: boolean
     game_only_width?: number
     game_only_height?: number
     main?: StoredMainWindowBounds
@@ -113,6 +115,16 @@ export function restoreAssistInGame(): boolean | undefined {
   return typeof assistInGame === 'boolean' ? assistInGame : undefined
 }
 
+export function restoreTopmost(): boolean | undefined {
+  const topmost = getAppJsonSetting().window?.topmost
+  return typeof topmost === 'boolean' ? topmost : undefined
+}
+
+export function restoreMuted(): boolean | undefined {
+  const muted = getAppJsonSetting().window?.muted
+  return typeof muted === 'boolean' ? muted : undefined
+}
+
 export function restoreMainWindowBounds(assistInGame: boolean): StoredMainWindowBounds | undefined {
   const windowSetting = getAppJsonSetting().window
   const savedBounds = assistInGame ? windowSetting?.main : windowSetting?.gameOnly
@@ -130,10 +142,12 @@ export function restoreGameOnlySize(): { width: number; height: number } | undef
   return { width, height }
 }
 
-export function saveMainWindowPosition(
+export function saveAppState(
   window: BrowserWindow,
   assistInGame: boolean,
-  gameOnlySize: { width: number; height: number }
+  gameOnlySize: { width: number; height: number },
+  topmost: boolean,
+  muted: boolean
 ): void {
   if (window.isDestroyed()) {
     return
@@ -145,6 +159,8 @@ export function saveMainWindowPosition(
   setting.window = {
     ...windowSetting,
     assist_in_game: assistInGame,
+    topmost,
+    muted,
     game_only_width: gameOnlySize.width,
     game_only_height: gameOnlySize.height,
     [assistInGame ? 'main' : 'gameOnly']: {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -84,7 +84,7 @@ app.on('before-quit', async (event) => {
     beforeQuitHandled = true
     const kcapp = getKcApp()
     if (kcapp) {
-      kcapp.saveMainWindowPosition()
+      kcapp.saveAppState()
       event.preventDefault()
       try {
         console.time('intakedrop and shutdown worker driver tid:'+ threadId)

--- a/src/main/kcbrowser.ts
+++ b/src/main/kcbrowser.ts
@@ -53,7 +53,7 @@ import { getMainDir, PathStuff, setUserDataDir } from '@main/path'
 import iconv from 'iconv-lite'
 import * as  kcapi_debug from '@main/kcapi_debug'
 import type { ApiReqMessage, ApiResMessage, QuestsMessage, RequiredMessage } from '@common/message'
-import { gameSetting, gameSettingProxy } from '@main/settings'
+import { gameSetting, gameSettingProxy, gameState } from '@main/settings'
 import path from 'node:path'
 import { getWorkerDriver, start as WorkersStart } from '@main/stuff/wrokers'
 import { AppSetting, defaultAppSetting, defaultInheritScoreList, InheritScoreList } from '@common/store'
@@ -63,11 +63,11 @@ import { AggregatedCellRank, AggregatedCellShipDrop } from '@common/calc_record'
 import { Intaker } from '@main/stuff/intaker'
 import { setTestData } from '@main/debug-data'
 import { UpdateCheckResult, UpdateStateSnapshot } from '@common/type'
-import { loadAppJsonSetting, restoreAssistInGame, restoreGameOnlySize, restoreMainWindowBounds, saveMainWindowPosition } from '@main/app_setting'
+import { loadAppJsonSetting, restoreAssistInGame, restoreGameOnlySize, restoreMainWindowBounds, restoreMuted, restoreTopmost, saveAppState } from '@main/app_setting'
 
 /////////////////////////////////////////////////////////////////////////////////////
 // debug
-const DEBUG = false;
+const DEBUG = 0;
 
 const debug = (...args: any[]) => {
   if (DEBUG) console.info("[KcBrowser]", ...args);
@@ -201,11 +201,11 @@ export class KcApp {
     return this.assist_window
   }
 
-  public saveMainWindowPosition(): void {
-    saveMainWindowPosition(this.mainWindow, gameSetting.assistInGame, {
+  public saveAppState(): void {
+    saveAppState(this.mainWindow, gameSetting.assistInGame, {
       width: appState.game_only_width,
       height: appState.game_only_height
-    })
+    }, gameSetting.topmost, gameState.muted)
   }
 
   constructor() { 
@@ -230,6 +230,14 @@ export class KcApp {
     const restoredAssistInGame = restoreAssistInGame()
     if (restoredAssistInGame !== undefined) {
       gameSetting.setAssistInGame(restoredAssistInGame)
+    }
+    const restoredTopmost = restoreTopmost()
+    if (restoredTopmost !== undefined) {
+      gameSetting.topmost = restoredTopmost
+    }
+    const restoredMuted = restoreMuted()
+    if (restoredMuted !== undefined) {
+      gameState.muted = restoredMuted
     }
     const restoredGameOnlySize = restoreGameOnlySize()
 
@@ -280,6 +288,7 @@ export class KcApp {
     ipcMain.handle(MainChannel.reload, async (_event, arg) => this.onChannelReload(arg))
     ipcMain.handle(MainChannel.openAssist, async () => this.onChannelOpenAssist())
     ipcMain.handle(MainChannel.topmost, async () => this.onChannelTopmost())
+    ipcMain.handle(MainChannel.notify_mute_state, async (_event, arg) => this.onChannelNotifyMuteState(arg))
     ipcMain.handle(MainChannel.open_capture_folder, async () => this.onChannelOpenCaptureFolder())
     ipcMain.handle(MainChannel.save_capture, async (_event, date, buffer) =>
       this.onChannelSaveCapture(date, buffer)
@@ -366,6 +375,9 @@ export class KcApp {
     if (Env.isTestMode) {
       additionalArguments.push(Const.ArgIsTestMode);
     }
+    if (gameState.muted) {
+      additionalArguments.push(Const.ArgIsInitMuted);
+    }
     const mainWindowOptions: BrowserWindowConstructorOptions = {
       useContentSize: true,
       width: withAssistSize.width,
@@ -439,7 +451,7 @@ export class KcApp {
     // open app html
     openAppHtml(this.mainWindow)
 
-    this.mainWindow.on('close', () => this.saveMainWindowPosition())
+    this.mainWindow.on('close', () => this.saveAppState())
     this.mainWindow.on('closed', () => this.onClosed())
     this.mainWindow.on('resize', () => this.onResize())
     this.mainWindow.on('will-resize', (event, newBounds, _details) =>
@@ -759,7 +771,7 @@ export class KcApp {
    */
   private async onChannelClose() {
     debug('on channel msg', MainChannel.close)
-    this.saveMainWindowPosition()
+    this.saveAppState()
     // no effect
     //mainWindow.close();
     this.mainWindow.destroy()
@@ -802,6 +814,14 @@ export class KcApp {
     debug(MainChannel.topmost)
     this.main_window.setAlwaysOnTop(!gameSetting.topmost)
     gameSetting.topmost = !gameSetting.topmost
+  }
+
+  /**
+   * 
+   */
+  private onChannelNotifyMuteState(muted: boolean) {
+    debug(MainChannel.notify_mute_state, 'muted:', muted)
+    gameState.muted = muted
   }
 
   /**

--- a/src/main/kcbrowser.ts
+++ b/src/main/kcbrowser.ts
@@ -817,7 +817,7 @@ export class KcApp {
   }
 
   /**
-   * 
+   * Keep the main-process mute state in sync with the renderer.
    */
   private onChannelNotifyMuteState(muted: boolean) {
     debug(MainChannel.notify_mute_state, 'muted:', muted)

--- a/src/main/settings.ts
+++ b/src/main/settings.ts
@@ -1,7 +1,9 @@
 import { IpcObject } from '@main/ipc'
 import { GameSetting } from '@common//setting'
+import { GameState } from '@common/state'
 import { GameChannel } from '@common/channel'
 
 const gameSetting_ = new GameSetting()
 export const gameSettingProxy = new IpcObject<GameSetting>(gameSetting_, GameChannel.set_game_setting)
 export const gameSetting = new Proxy(gameSetting_, gameSettingProxy)
+export const gameState = new GameState()

--- a/src/preload/api.d.ts
+++ b/src/preload/api.d.ts
@@ -19,6 +19,7 @@ export interface Api {
   saveCapture(date: Date, buffer: Buffer): void
   openAssist(): void
   topmost(): void
+  notifyMuteState(muted: boolean): void
   refreshAssist(): void
   storeRec(buffer: Buffer, isEnd: boolean): void
   requestRequiredData(): void

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -57,6 +57,10 @@ const api: Api = {
     ipcRenderer.invoke(MainChannel.topmost)
   },
 
+  notifyMuteState(muted: boolean): void {
+    ipcRenderer.invoke(MainChannel.notify_mute_state, muted)
+  },
+
   storeRec(buffer: Buffer, isEnd: boolean) {
     ipcRenderer.invoke(MainChannel.store_rec, buffer, isEnd)
   },

--- a/src/renderer/src/App.vue
+++ b/src/renderer/src/App.vue
@@ -161,7 +161,7 @@ const onGameDevTool = (): void => {
 }
 
 const onMute = (): void => {
-  getGame()?.setMute(!gameState.muted)
+  getGame()?.setMute(!gameState.muted, true)
 }
 </script>
 

--- a/src/renderer/src/common/env-renderer.ts
+++ b/src/renderer/src/common/env-renderer.ts
@@ -1,10 +1,14 @@
 import { Const } from '@common/const'
 const isAssist = !!process.argv.find((a) => a.startsWith(Const.ArgIsAssist))
+const isInitMuted = !!process.argv.find((a) => a.startsWith(Const.ArgIsInitMuted))
 const isTestMode = !!process.argv.find((a) => a.startsWith(Const.ArgIsTestMode))
 
 export class EnvRenderer {
   static get isAssist(): boolean {
     return isAssist
+  }
+  static get isInitMuted(): boolean {
+    return isInitMuted
   }
   static get isTestMode(): boolean {
     return isTestMode

--- a/src/renderer/src/components/Game.vue
+++ b/src/renderer/src/components/Game.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { ref, onMounted, watch, onUnmounted } from 'vue'
 
-const DEBUG = false;
+const DEBUG = 0;
 
 const debugLog = (...args: any[]) => {
   if (DEBUG) console.debug("[game webview]", ...args);
@@ -17,6 +17,9 @@ import { gameState } from '@renderer/store/gamestate'
 import { EnvRenderer } from '@renderer/common/env-renderer'
 const ipcRenderer = window.electron.ipcRenderer
 const el = ref<HTMLElement | null>(null)
+
+// mute状態はDOM-READY後ではないと設定できないことに注意
+let mutedStateApplied = false
 
 const StageType = {
   None: 0,
@@ -78,6 +81,7 @@ onMounted(() => {
     webview.addEventListener('media-started-playing', mediaStartedPlaying)
     webview.addEventListener('media-paused', mediaPaused)
   }
+
   ipcRenderer.on(GameChannel.set_zoom_factor, setZoomFactor)
   debugLog('game mounted <<')
 })
@@ -105,6 +109,24 @@ function setZoomFactor(_event: IpcRendererEvent, factor: number): void {
 
 function domReady(_event: Event): void {
   debugLog('domReady domRady')
+
+  // apply muted state if needed
+  if (!mutedStateApplied) {
+    mutedStateApplied = true
+    debugLog('apply muted state in domReady, muted:', gameState.muted)
+
+    if (EnvRenderer.isInitMuted) {
+      // mute状態では無ければmuteに設定
+      const wevbview = getWebview()
+      if (wevbview) {
+        debugLog('initially muted. check webview muted state:', wevbview?.isAudioMuted())
+        if (!wevbview.isAudioMuted()) {
+          setMute(true, false)
+        }
+      }
+    }
+  }
+
   getWebviewUnsafe().setZoomFactor(gameSetting.zoom_factor)
 }
 
@@ -212,13 +234,18 @@ function mediaPaused(_event: Event): void {
   debugLog('mediaPaused')
 }
 
-function setMute(mute: boolean): void {
+function setMute(mute: boolean, notifyCheck: boolean): void {
   const webview = getWebview()
   if (webview) {
-    debugLog('now muted:', webview.isAudioMuted())
+    const oldMuted = gameState.muted
+    debugLog('now webview muted:', webview.isAudioMuted(), 'muted state:', oldMuted, 'notifyCheck:', notifyCheck)
     webview.setAudioMuted(mute)
     gameState.muted = webview.isAudioMuted()
     debugLog('set muted:', gameState.muted)
+    if (notifyCheck && oldMuted !== gameState.muted) {
+      debugLog('notify mute state changed:', gameState.muted)
+      window.api.notifyMuteState(gameState.muted)
+    }
   }
 }
 

--- a/src/renderer/src/components/Game.vue
+++ b/src/renderer/src/components/Game.vue
@@ -108,7 +108,7 @@ function setZoomFactor(_event: IpcRendererEvent, factor: number): void {
 }
 
 function domReady(_event: Event): void {
-  debugLog('domReady domRady')
+  debugLog('domReady')
 
   // apply muted state if needed
   if (!mutedStateApplied) {

--- a/src/renderer/src/components/Game.vue
+++ b/src/renderer/src/components/Game.vue
@@ -117,10 +117,10 @@ function domReady(_event: Event): void {
 
     if (EnvRenderer.isInitMuted) {
       // mute状態では無ければmuteに設定
-      const wevbview = getWebview()
-      if (wevbview) {
-        debugLog('initially muted. check webview muted state:', wevbview?.isAudioMuted())
-        if (!wevbview.isAudioMuted()) {
+      const webview = getWebview()
+      if (webview) {
+        debugLog('initially muted. check webview muted state:', webview.isAudioMuted())
+        if (!webview.isAudioMuted()) {
           setMute(true, false)
         }
       }

--- a/src/renderer/src/main.ts
+++ b/src/renderer/src/main.ts
@@ -1,6 +1,7 @@
 import { GameChannel } from '@common/channel'
 import { GameSetting } from '@common/setting'
 import { AppState } from '@common/state'
+import { gameState } from '@renderer/store/gamestate'
 import { gameSetting } from '@renderer/store/gamesetting'
 import { createApp } from 'vue'
 import Buefy from 'buefy'
@@ -21,6 +22,11 @@ import { EnvRenderer } from './common/env-renderer'
 // if assist window change title
 if (EnvRenderer.isAssist) {
   document.title = '甲ブラウザ アシストウィンドウ';
+}
+
+// ボタン状態はアプリコンポ表示前に反映させておく
+if (EnvRenderer.isInitMuted) {
+  gameState.muted = true
 }
 
 streamInitialize(async () => {


### PR DESCRIPTION
## Summary
- Persist app window state values in `koubrowser.json`, including `topmost` and `muted`
- Restore saved `topmost` and main-process `muted` state on startup
- Pass the initial muted state to the renderer and notify main when mute changes
- Rename the app-state save path from `saveMainWindowPosition` to `saveAppState`

## Validation
- `npm run typecheck`
- `npx vitest run src/main/__tests__/app_setting.test.ts`

## Notes
- `npm run lint` was not run per current project instruction to avoid running it until explicitly requested.
