### PR TITLE
[codex] Persist assist window state

### DIFF
--- a/src/main/__tests__/app_setting.test.ts
+++ b/src/main/__tests__/app_setting.test.ts
@@ -45,6 +45,11 @@ const originalSetting = {
     game_only_height: 1007,
     topmost: true,
     muted: true,
+    assistWindow: {
+      visible: true,
+      x: 100,
+      y: 120
+    },
     abc: 10,
     aaa: 0,
     anyobj: {
@@ -59,6 +64,16 @@ const originalSetting = {
 describe('app_setting', () => {
   beforeEach(() => {
     mockState.userDataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'koubrowser-app-setting-'))
+    mockState.displays = [
+      {
+        bounds: {
+          x: 0,
+          y: 0,
+          width: 1920,
+          height: 1080
+        }
+      }
+    ]
     fs.writeFileSync(
       path.join(mockState.userDataDir, 'koubrowser.json'),
       JSON.stringify(originalSetting, undefined, ' '),
@@ -95,6 +110,12 @@ describe('app_setting', () => {
     })
     expect(appSetting.restoreTopmost()).toBe(true)
     expect(appSetting.restoreMuted()).toBe(true)
+    expect(appSetting.restoreAssistWindowState(true)).toEqual({
+      position: {
+        x: 100,
+        y: 120
+      }
+    })
 
     appSetting.saveAppState(
       {
@@ -112,7 +133,7 @@ describe('app_setting', () => {
         height: 900
       },
       false,
-      false
+      false,
     )
 
     const saved = JSON.parse(
@@ -126,6 +147,11 @@ describe('app_setting', () => {
     expect(saved.window.assist_in_game).toBe(false)
     expect(saved.window.topmost).toBe(false)
     expect(saved.window.muted).toBe(false)
+    expect(saved.window.assistWindow).toEqual({
+      visible: true,
+      x: 100,
+      y: 120
+    })
     expect(saved.window.game_only_width).toBe(1200)
     expect(saved.window.game_only_height).toBe(900)
     expect(saved.window.gameOnly).toEqual({
@@ -134,5 +160,111 @@ describe('app_setting', () => {
       width: 1200,
       height: 900
     })
+  })
+
+  it('saves visible assist window position', async () => {
+    const appSetting = await import('../app_setting')
+
+    appSetting.loadAppJsonSetting()
+
+    appSetting.saveAppState(
+      {
+        isDestroyed: () => false,
+        getBounds: () => ({
+          x: 20,
+          y: 30,
+          width: 1200,
+          height: 900
+        })
+      } as Electron.BrowserWindow,
+      true,
+      {
+        width: 1541,
+        height: 1007
+      },
+      true,
+      true
+    )
+
+    const saved = JSON.parse(
+      fs.readFileSync(path.join(mockState.userDataDir, 'koubrowser.json'), 'utf8')
+    )
+    expect(saved.window.assistWindow).toEqual({
+      visible: true,
+      x: 100,
+      y: 120
+    })
+    expect(saved.window.assistWindow.width).toBeUndefined()
+    expect(saved.window.assistWindow.height).toBeUndefined()
+  })
+
+  it('keeps assist window position without visible flag when it is hidden', async () => {
+    const appSetting = await import('../app_setting')
+
+    appSetting.loadAppJsonSetting()
+    appSetting.updateAssistWindowState(
+      {
+        isDestroyed: () => false,
+        isVisible: () => false,
+        getNormalBounds: () => ({
+          x: 300,
+          y: 320,
+          width: 1200,
+          height: 900
+        })
+      } as Electron.BrowserWindow,
+      false
+    )
+    appSetting.saveAppState(
+      {
+        isDestroyed: () => false,
+        getBounds: () => ({
+          x: 20,
+          y: 30,
+          width: 1200,
+          height: 900
+        })
+      } as Electron.BrowserWindow,
+      true,
+      {
+        width: 1541,
+        height: 1007
+      },
+      true,
+      true
+    )
+
+    const saved = JSON.parse(
+      fs.readFileSync(path.join(mockState.userDataDir, 'koubrowser.json'), 'utf8')
+    )
+    expect(saved.window.assistWindow).toEqual({
+      x: 300,
+      y: 320
+    })
+    expect(appSetting.restoreAssistWindowState(false)).toEqual({
+      position: {
+        x: 300,
+        y: 320
+      }
+    })
+  })
+
+  it('does not restore assist window position outside displays', async () => {
+    mockState.displays = [
+      {
+        bounds: {
+          x: 0,
+          y: 0,
+          width: 100,
+          height: 100
+        }
+      }
+    ]
+
+    const appSetting = await import('../app_setting')
+
+    appSetting.loadAppJsonSetting()
+
+    expect(appSetting.restoreAssistWindowState(true)).toEqual({})
   })
 })

--- a/src/main/app_setting.ts
+++ b/src/main/app_setting.ts
@@ -213,7 +213,6 @@ export function saveAppState(
   muted: boolean
 ): void {
   if (window.isDestroyed()) {
-    console.log('Main window is destroyed. Skipping saveAppState.')
     return
   }
 

--- a/src/main/app_setting.ts
+++ b/src/main/app_setting.ts
@@ -9,6 +9,19 @@ interface StoredMainWindowBounds {
   readonly height: number
 }
 
+interface StoredAssistWindowState {
+  readonly visible?: true
+  readonly x: number
+  readonly y: number
+}
+
+export interface RestoredAssistWindowState {
+  readonly position?: {
+    readonly x: number
+    readonly y: number
+  }
+}
+
 interface AppJsonSetting {
   window?: {
     assist_in_game?: boolean
@@ -18,6 +31,7 @@ interface AppJsonSetting {
     game_only_height?: number
     main?: StoredMainWindowBounds
     gameOnly?: StoredMainWindowBounds
+    assistWindow?: StoredAssistWindowState
   }
 }
 
@@ -110,6 +124,21 @@ function restoreWindowBounds(savedBounds: unknown): StoredMainWindowBounds | und
   return savedBounds
 }
 
+function getAssistWindowState(
+  window: BrowserWindow,
+  isClosed: boolean
+): StoredAssistWindowState | undefined {
+  if (!window.isDestroyed()) {
+    const normalBounds = window.getNormalBounds()
+    return {
+      visible: isClosed ? undefined : (window.isVisible() ? true : undefined),
+      x: normalBounds.x,
+      y: normalBounds.y
+    }
+  }
+  return undefined
+}
+
 export function restoreAssistInGame(): boolean | undefined {
   const assistInGame = getAppJsonSetting().window?.assist_in_game
   return typeof assistInGame === 'boolean' ? assistInGame : undefined
@@ -142,6 +171,41 @@ export function restoreGameOnlySize(): { width: number; height: number } | undef
   return { width, height }
 }
 
+export function restoreAssistWindowState(visibleOnly: boolean): RestoredAssistWindowState | undefined {
+  const assistWindow = getAppJsonSetting().window?.assistWindow
+  if (!isPlainObject(assistWindow)) {
+    return undefined
+  }
+
+  if (visibleOnly && assistWindow.visible !== true) {
+    return undefined
+  }
+
+  if (!isFiniteNumber(assistWindow.x) || !isFiniteNumber(assistWindow.y)) {
+    return {}
+  }
+
+  const position = { x: assistWindow.x, y: assistWindow.y }
+  return isPositionInAnyDisplay(position) ? { position } : {}
+}
+
+export function updateAssistWindowState(
+  assistWindow: BrowserWindow,
+  isClosed: boolean
+): void {
+  const assistWindowState = getAssistWindowState(assistWindow, isClosed)
+  console.log('updateAssistWindowState:', assistWindowState, 'isClosed:', isClosed)
+  if (!assistWindowState) {
+    return
+  }
+  const setting = getAppJsonSetting()
+  const windowSetting = isPlainObject(setting.window) ? setting.window : {}
+  setting.window = {
+    ...windowSetting,
+    assistWindow: assistWindowState
+  }
+}
+
 export function saveAppState(
   window: BrowserWindow,
   assistInGame: boolean,
@@ -150,6 +214,7 @@ export function saveAppState(
   muted: boolean
 ): void {
   if (window.isDestroyed()) {
+    console.log('Main window is destroyed. Skipping saveAppState.')
     return
   }
 

--- a/src/main/app_setting.ts
+++ b/src/main/app_setting.ts
@@ -194,7 +194,6 @@ export function updateAssistWindowState(
   isClosed: boolean
 ): void {
   const assistWindowState = getAssistWindowState(assistWindow, isClosed)
-  console.log('updateAssistWindowState:', assistWindowState, 'isClosed:', isClosed)
   if (!assistWindowState) {
     return
   }

--- a/src/main/kcbrowser.ts
+++ b/src/main/kcbrowser.ts
@@ -457,6 +457,14 @@ export class KcApp {
       this.openAssistWindow(restoredAssistWindowState.position)
     }
 
+    // Persist window state before any child windows are closed by the main window shutdown path.
+    this.mainWindow.on('close', () => {
+      if (this.assist_window && !this.assist_window.isDestroyed()) {
+        updateAssistWindowState(this.assist_window, false)
+      }
+      this.saveAppState()
+    })
+
     this.mainWindow.on('closed', () => this.onClosed())
     this.mainWindow.on('resize', () => this.onResize())
     this.mainWindow.on('will-resize', (event, newBounds, _details) =>

--- a/src/main/kcbrowser.ts
+++ b/src/main/kcbrowser.ts
@@ -63,7 +63,7 @@ import { AggregatedCellRank, AggregatedCellShipDrop } from '@common/calc_record'
 import { Intaker } from '@main/stuff/intaker'
 import { setTestData } from '@main/debug-data'
 import { UpdateCheckResult, UpdateStateSnapshot } from '@common/type'
-import { loadAppJsonSetting, restoreAssistInGame, restoreGameOnlySize, restoreMainWindowBounds, restoreMuted, restoreTopmost, saveAppState } from '@main/app_setting'
+import { loadAppJsonSetting, restoreAssistInGame, restoreAssistWindowState, restoreGameOnlySize, restoreMainWindowBounds, restoreMuted, restoreTopmost, saveAppState, updateAssistWindowState } from '@main/app_setting'
 
 /////////////////////////////////////////////////////////////////////////////////////
 // debug
@@ -202,6 +202,7 @@ export class KcApp {
   }
 
   public saveAppState(): void {
+    debug('saveAppState called')
     saveAppState(this.mainWindow, gameSetting.assistInGame, {
       width: appState.game_only_width,
       height: appState.game_only_height
@@ -240,6 +241,7 @@ export class KcApp {
       gameState.muted = restoredMuted
     }
     const restoredGameOnlySize = restoreGameOnlySize()
+    const restoredAssistWindowState = restoreAssistWindowState(true)
 
     // Create the browser window.
     const restoredMainWindowBounds = restoreMainWindowBounds(gameSetting.isAssistInGame)
@@ -451,7 +453,10 @@ export class KcApp {
     // open app html
     openAppHtml(this.mainWindow)
 
-    this.mainWindow.on('close', () => this.saveAppState())
+    if (restoredAssistWindowState) {
+      this.openAssistWindow(restoredAssistWindowState.position)
+    }
+
     this.mainWindow.on('closed', () => this.onClosed())
     this.mainWindow.on('resize', () => this.onResize())
     this.mainWindow.on('will-resize', (event, newBounds, _details) =>
@@ -554,7 +559,7 @@ export class KcApp {
   /**
    *
    */
-  private openAssistWindow(): void {
+  private openAssistWindow(position?: { x: number; y: number }): void {
     if (this.assist_window) {
       // noop
       return
@@ -563,6 +568,11 @@ export class KcApp {
     //
     const pos = this.main_window.getPosition()
     const size = this.main_window.getSize()
+    const defaultPosition = {
+      x: pos[0] + size[0] - 100,
+      y: pos[1]
+    }
+    const assistWindowPosition = position ?? defaultPosition
     const additionalArguments: string[] = [Const.ArgIsAssist];
     if (Env.isTestMode) {
       additionalArguments.push(Const.ArgIsTestMode);
@@ -573,8 +583,8 @@ export class KcApp {
       useContentSize: true,
       width: Const.AssistWidth,
       height: size[1] - Const.TitleBarHeight,
-      x: pos[0] + size[0] - 100,
-      y: pos[1],
+      x: assistWindowPosition.x,
+      y: assistWindowPosition.y,
       webPreferences: {
         nodeIntegration: true,
         contextIsolation: false,
@@ -589,6 +599,12 @@ export class KcApp {
     this.assist_window.setMenu(null)
 
     debug('assist window id', this.assist_window.id)
+    this.assist_window.addListener('close', () => {
+      // 閉じた位置を保存
+      if (this.assist_window) {
+        updateAssistWindowState(this.assist_window!, true)
+      }
+    })
     this.assist_window.addListener('closed', () => {
       this.assist_window = null
     })
@@ -771,6 +787,12 @@ export class KcApp {
    */
   private async onChannelClose() {
     debug('on channel msg', MainChannel.close)
+
+    // update assist windows pos
+    if (this.assist_window?.isVisible()) {
+      updateAssistWindowState(this.assist_window, false)
+    }
+
     this.saveAppState()
     // no effect
     //mainWindow.close();
@@ -833,7 +855,8 @@ export class KcApp {
       this.assist_window.show()
       this.assist_window.focus()
     } else {
-      this.openAssistWindow()
+      const state = restoreAssistWindowState(false)
+      this.openAssistWindow(state?.position)
     }
   }
 


### PR DESCRIPTION
## Summary
- Persist the assist window state in `koubrowser.json`
- Restore the assist window on startup when it was visible at shutdown
- Keep the last assist window position even when the assist window is closed or hidden
- Add app setting tests for visible-only restore and position restore behavior

## Validation
- `npm run typecheck`
- `npx vitest run src/main/__tests__/app_setting.test.ts`

## Notes
- `npm run lint` was not run per current project instruction to avoid running it until explicitly requested.
