### PR TITLE
fix improve app layout on screens smaller than 1800x960

### DIFF
--- a/src/common/const.ts
+++ b/src/common/const.ts
@@ -15,12 +15,14 @@ export type SupportCodecs =
 //console.log(navigator.mediaDevices.getSupportedConstraints());
 
 export class Const {
+  static readonly InGameAssistDisplayRequirementWidth = 1800
+  static readonly InGameAssistDisplayRequirementHeight = 960
   static readonly GameWidth = 1200
   static readonly GameHeight = 720
   static readonly GameBarHeight = 40
   static readonly TitleBarHeight = 32
   static readonly MaxMedals = 33
-  static readonly AssistHeight = 202 - 34
+  static readonly AssistBottomHeight = 202 - 34
   static readonly AssistWidth = 600
   static readonly AppUserModelId = 'com.koubrowser.app'
   static readonly ArgIsAssist = '--is-assist'

--- a/src/common/rect_util.ts
+++ b/src/common/rect_util.ts
@@ -1,0 +1,26 @@
+
+export type Rect = {
+  x: number
+  y: number
+  width: number
+  height: number
+}
+export function intersect(a: Rect, b: Rect): Rect | undefined {
+  const left = Math.max(a.x, b.x)
+  const top = Math.max(a.y, b.y)
+  const right = Math.min(a.x + a.width, b.x + b.width)
+  const bottom = Math.min(a.y + a.height, b.y + b.height)
+
+  if (left >= right || top >= bottom) {
+    // 重なりなし
+    return undefined
+  }
+
+  return {
+    x: left,
+    y: top,
+    width: right - left,
+    height: bottom - top,
+  }
+
+}

--- a/src/common/setting.ts
+++ b/src/common/setting.ts
@@ -14,10 +14,10 @@ export class GameSetting {
   public capture_codec: SupportCodecs = 'video/webm;codecs=vp9,opus'
 
   private assist_in_game: boolean = true
-  public assist_ok: boolean = true
+  private assist_restricted: boolean = false
 
   public get isAssistInGame(): boolean {
-    return this.assist_ok && this.assist_in_game
+    return !this.assist_restricted && this.assist_in_game
   }
 
   public get assistInGame(): boolean {
@@ -26,5 +26,13 @@ export class GameSetting {
 
   public setAssistInGame(inGame: boolean): void {
     this.assist_in_game = inGame
+  }
+
+  public get assistRestricted(): boolean {
+    return this.assist_restricted
+  }
+  
+  public setAssistRestricted(restricted: boolean): void {
+    this.assist_restricted = restricted
   }
 }

--- a/src/main/app_setting.ts
+++ b/src/main/app_setting.ts
@@ -1,4 +1,4 @@
-import { app, BrowserWindow, Rectangle, screen } from 'electron'
+import { app, BrowserWindow, Display, Rectangle, screen } from 'electron'
 import * as fs from 'fs'
 import path from 'node:path'
 
@@ -107,8 +107,8 @@ function isPositionInBounds(position: { x: number; y: number }, bounds: Rectangl
   )
 }
 
-function isPositionInAnyDisplay(position: { x: number; y: number }): boolean {
-  return screen.getAllDisplays().some((display) => isPositionInBounds(position, display.bounds))
+function isPositionInAnyDisplay(position: { x: number; y: number }): Display | undefined {
+  return screen.getAllDisplays().find((display) => isPositionInBounds(position, display.bounds))
 }
 
 function restoreWindowBounds(savedBounds: unknown): StoredMainWindowBounds | undefined {
@@ -171,7 +171,7 @@ export function restoreGameOnlySize(): { width: number; height: number } | undef
   return { width, height }
 }
 
-export function restoreAssistWindowState(visibleOnly: boolean): RestoredAssistWindowState | undefined {
+export function restoreAssistWindowState(visibleOnly: boolean): RestoredAssistWindowState & { display: Display} | undefined {
   const assistWindow = getAppJsonSetting().window?.assistWindow
   if (!isPlainObject(assistWindow)) {
     return undefined
@@ -182,11 +182,12 @@ export function restoreAssistWindowState(visibleOnly: boolean): RestoredAssistWi
   }
 
   if (!isFiniteNumber(assistWindow.x) || !isFiniteNumber(assistWindow.y)) {
-    return {}
+    return undefined
   }
 
   const position = { x: assistWindow.x, y: assistWindow.y }
-  return isPositionInAnyDisplay(position) ? { position } : {}
+  const display = isPositionInAnyDisplay(position)
+  return display ? { position, display } : undefined
 }
 
 export function updateAssistWindowState(
@@ -234,5 +235,24 @@ export function saveAppState(
     }
   }
 
+  writeAppJsonSetting(setting)
+}
+
+export function saveAppStateRestricted(
+  window: BrowserWindow,
+  topmost: boolean,
+  muted: boolean
+): void {
+  if (window.isDestroyed()) {
+    return
+  }
+
+  const setting = getAppJsonSetting()
+  const windowSetting = isPlainObject(setting.window) ? setting.window : {}
+  setting.window = {
+    ...windowSetting,
+    topmost,
+    muted
+  }
   writeAppJsonSetting(setting)
 }

--- a/src/main/kcbrowser.ts
+++ b/src/main/kcbrowser.ts
@@ -16,6 +16,7 @@ import {
   IpcMainInvokeEvent,
   MenuItem,
   Menu,
+  Display,
 } from 'electron'
 import { autoUpdater } from 'electron-updater'
 import { is } from '@electron-toolkit/utils'
@@ -63,7 +64,8 @@ import { AggregatedCellRank, AggregatedCellShipDrop } from '@common/calc_record'
 import { Intaker } from '@main/stuff/intaker'
 import { setTestData } from '@main/debug-data'
 import { UpdateCheckResult, UpdateStateSnapshot } from '@common/type'
-import { loadAppJsonSetting, restoreAssistInGame, restoreAssistWindowState, restoreGameOnlySize, restoreMainWindowBounds, restoreMuted, restoreTopmost, saveAppState, updateAssistWindowState } from '@main/app_setting'
+import * as appSetting from '@main/app_setting'
+import * as RectUtil from '@common/rect_util'
 import crypto from 'node:crypto'
 
 /////////////////////////////////////////////////////////////////////////////////////
@@ -125,11 +127,11 @@ type UpdateChannel = 'beta' | 'latest'
 /**
  *
  */
-const calcAssistWindowSize = (): { width: number; height: number } => {
-  if (gameSetting.isAssistInGame) {
+const calcMainWindowSize = (isAssistInGame: boolean): { width: number; height: number } => {
+  if (isAssistInGame) {
     const width = Const.GameWidth + Const.AssistWidth
     const height =
-      Const.GameHeight + Const.GameBarHeight + Const.TitleBarHeight + Const.AssistHeight
+      Const.GameHeight + Const.GameBarHeight + Const.TitleBarHeight + Const.AssistBottomHeight
     return { width, height }
   }
 
@@ -143,10 +145,64 @@ const calcAssistWindowSize = (): { width: number; height: number } => {
 /**
  *
  */
-const calcGameOnlySize = (): { width: number; height: number } => {
+const defaultGameOnlySize = (): { width: number; height: number } => {
   const width = Const.GameWidth
   const height = Const.GameHeight + Const.GameBarHeight + Const.TitleBarHeight
   return { width, height }
+}
+
+/**
+ * 
+ */
+const calcMainWindowMinSize = (): { minWidth: number; minHeight: number, frame_ratio: number } => {
+  const defGameOnlySize = defaultGameOnlySize()
+  const frame_ratio = AppStuff.calcFrameRatio(defGameOnlySize.width, defGameOnlySize.height)
+  const minWidth = 600
+  const minHeight = AppStuff.calcFrameHeight(frame_ratio, minWidth)
+  gameSetting.zoom_factor = AppStuff.calcGameZoomFactor(defGameOnlySize.width)
+  return { minWidth, minHeight, frame_ratio }
+}
+
+
+/**
+ * 
+ */
+const isAssistRestricted = (): boolean => {
+  //screen.getAllDisplays().forEach(el => console.log(el));
+  // const pdisp = screen.getPrimaryDisplay()
+  // const ok = [pdisp].some((el) => {
+  //   return el.bounds.height >= Const.InGameAssistDisplayRequirementHeight && 
+  //   el.bounds.width >= Const.InGameAssistDisplayRequirementWidth
+  // })
+  //debug('primary display:', pdisp, 'has required size:', ok)
+  const ok = screen
+    .getAllDisplays()
+    .some((el) => {
+      return el.bounds.height >= Const.InGameAssistDisplayRequirementHeight && 
+      el.bounds.width >= Const.InGameAssistDisplayRequirementWidth}
+    )
+  return !ok;
+}
+
+/**
+ * 
+ */
+const installVueDevtoolsIfDev = (): void => {
+  if (Env.isDevelopment) {
+    const path =
+      process.env.LOCALAPPDATA +
+      '/Google/Chrome/User Data/Default/Extensions/nhdogjmejiglipccpnnnanhbledajbpd/7.7.7_0'
+    if (fs.existsSync(path)) {
+      session.defaultSession.extensions
+        .loadExtension(path, { allowFileAccess: true })
+        .then(() => {
+          debug('Vue Devtools loaded')
+        })
+        .catch((err) => {
+          debug('Vue Devtools load failed:', err)
+        })
+    }
+  }
 }
 
 /**
@@ -177,7 +233,7 @@ export class KcApp {
   private assist_window: BrowserWindow | null = null
   private frame_ratio: number
   private kcrecord: KcRecord | null = null
-  private cbBasicFirst: number
+  private cbBasicFirst: number = 0
   private nohandle_resize: boolean = false
   private wsRecording: fs.WriteStream | null = null
   private questUpdated_called: boolean = false
@@ -203,11 +259,20 @@ export class KcApp {
   }
 
   public saveAppState(): void {
-    debug('saveAppState called')
-    saveAppState(this.mainWindow, gameSetting.assistInGame, {
-      width: appState.game_only_width,
-      height: appState.game_only_height
-    }, gameSetting.topmost, gameState.muted)
+    debug('saveAppState called isRestricted:', gameSetting.assistRestricted)
+
+    // ディスプレイ要件を満たすディスプレイがない場合は
+    // ・ミュート状態
+    // ・topmost状態
+    // のみ保存する
+    if (gameSetting.assistRestricted) {
+      appSetting.saveAppStateRestricted(this.mainWindow, gameSetting.topmost, gameState.muted)
+    } else {
+      appSetting.saveAppState(this.mainWindow, gameSetting.assistInGame, {
+        width: appState.game_only_width,
+        height: appState.game_only_height
+      }, gameSetting.topmost, gameState.muted)
+    }
   }
 
   constructor() { 
@@ -224,63 +289,371 @@ export class KcApp {
 
     // set user data dir
     setUserDataDir(app.getPath('userData'))
-    loadAppJsonSetting()
-
-    // check assist stuff
-    gameSetting.assist_ok = screen
-      .getAllDisplays()
-      .some((el) => el.bounds.height >= 960 && el.bounds.width >= 1800)
-    //screen.getAllDisplays().forEach(el => console.log(el));
-
-    const restoredAssistInGame = restoreAssistInGame()
-    if (restoredAssistInGame !== undefined) {
-      gameSetting.setAssistInGame(restoredAssistInGame)
-    }
-    const restoredTopmost = restoreTopmost()
-    if (restoredTopmost !== undefined) {
-      gameSetting.topmost = restoredTopmost
-    }
-    const restoredMuted = restoreMuted()
-    if (restoredMuted !== undefined) {
-      gameState.muted = restoredMuted
-    }
-    const restoredGameOnlySize = restoreGameOnlySize()
-    const restoredAssistWindowState = restoreAssistWindowState(true)
-
-    // Create the browser window.
-    const restoredMainWindowBounds = restoreMainWindowBounds(gameSetting.isAssistInGame)
-    const withAssistSize = restoredMainWindowBounds ?? calcAssistWindowSize()
-    const gameOnlySize = calcGameOnlySize()
-    const mainWindowPosition = restoredMainWindowBounds
-      ? { x: restoredMainWindowBounds.x, y: restoredMainWindowBounds.y }
-      : undefined
-    const mainWindowPlacement = mainWindowPosition ?? { center: true }
-
-    this.frame_ratio = AppStuff.calcFrameRatio(gameOnlySize.width, gameOnlySize.height)
-    const minWidth = 600
-    const minHeight = AppStuff.calcFrameHeight(this.frame_ratio, minWidth)
-    gameSetting.zoom_factor = AppStuff.calcGameZoomFactor(gameOnlySize.width)
+    appSetting.loadAppJsonSetting()
 
     // set useragent
     setUseragent()
 
     // install Vue.js devtools
-    if (Env.isDevelopment) {
-      const path =
-        process.env.LOCALAPPDATA +
-        '/Google/Chrome/User Data/Default/Extensions/nhdogjmejiglipccpnnnanhbledajbpd/7.7.7_0'
-      if (fs.existsSync(path)) {
-        session.defaultSession.extensions
-          .loadExtension(path, { allowFileAccess: true })
-          .then(() => {
-            debug('Vue Devtools loaded')
-          })
-          .catch((err) => {
-            debug('Vue Devtools load failed:', err)
-          })
+    installVueDevtoolsIfDev()
+
+    // イベントやIPCハンドラ設定
+    this.setupHandlers()
+
+    // detect restricted assist
+    gameSetting.setAssistRestricted(isAssistRestricted())
+
+    // calc main window min size
+    const { minWidth, minHeight, frame_ratio } = calcMainWindowMinSize();
+    this.frame_ratio = frame_ratio
+
+    // メインウインドウにアシストを表示するか？
+    // ディスプレイ要件を満たすディスプレイがない場合は、アシストをゲームと別ウインドウで表示する
+    if (gameSetting.assistRestricted) {
+      gameSetting.setAssistInGame(false)
+    } else {
+      const restoredAssistInGame = appSetting.restoreAssistInGame()
+      if (restoredAssistInGame !== undefined) {
+        gameSetting.setAssistInGame(restoredAssistInGame)
       }
     }
 
+    const restoredTopmost = appSetting.restoreTopmost()
+    if (restoredTopmost !== undefined) {
+      gameSetting.topmost = restoredTopmost
+    }
+    const restoredMuted = appSetting.restoreMuted()
+    if (restoredMuted !== undefined) {
+      gameState.muted = restoredMuted
+    }
+
+    // Create the browser window.
+
+    // 前回終了ウインドウ位置で現環境のdisplayに表示できる場合の座標取得
+    // 取得できない場合、undef
+    const restoredMainWindowBounds = appSetting.restoreMainWindowBounds(gameSetting.isAssistInGame)
+
+    // メインウインドウ表示サイズ
+    const mainWindowSize = ((): { width: number, height: number, resizable: boolean } => {
+
+      // 推奨サイズの要件を満たすディスプレイがない場合はゲーム画面と別ウインドウアシストを表示する
+      // プライマリディスプレイに表示する
+      if (gameSetting.assistRestricted) {
+        const primaryDisplay = screen.getPrimaryDisplay()
+        const bounds = primaryDisplay.workArea
+        const width = Math.max(bounds.width - Const.AssistWidth, minWidth)
+        const height = AppStuff.calcFrameHeight(frame_ratio, width)
+        return { width, height, resizable: true }
+      }
+
+      // 前回起動座標が無効
+      if (! restoredMainWindowBounds) {
+        // デフォルト初期サイズで表示
+        return { ...calcMainWindowSize(gameSetting.isAssistInGame), resizable: !gameSetting.isAssistInGame }
+      }
+
+      // 前回起動座標が有効
+      if (gameSetting.isAssistInGame) {
+        // サイズは固定
+        return { ...calcMainWindowSize(true), resizable: false }
+      }
+
+      // ゲームのみ表示、保存されているサイズを返却
+      return { width: restoredMainWindowBounds.width, height: restoredMainWindowBounds.height, resizable: true }
+    })()
+
+    // メインウインドウ表示位置
+    const mainWindowPos = ((): { x: number, y: number } | undefined => {
+
+      // 推奨サイズの要件を満たすディスプレイがない場合
+      if (gameSetting.assistRestricted) {
+        // 表示位置保存が無い場合、プライマリディスプレイに表示する
+        const primaryDisplay = screen.getPrimaryDisplay()
+        const bounds = primaryDisplay.workArea
+        return { x: bounds.x, y: bounds.y + (bounds.height - mainWindowSize.height)/2 }
+      }
+
+      // 前回起動座標が無効
+      if (! restoredMainWindowBounds) {
+        // 表示位置を指定しない
+        return undefined
+      }
+
+      // 前回起動座標が有効
+      return { x: restoredMainWindowBounds.x, y: restoredMainWindowBounds.y }
+    })()
+
+    // 表示座標を指定しない場合、中央表示
+    const mainWindowPlacement = mainWindowPos ?? { center: true }
+
+    // create main frame
+    const additionalArguments: string[] = [];
+    additionalArguments.push(`--${Const.ArgAppLaunchId}=${appLaunchId}`);
+    if (Env.isTestMode) {
+      additionalArguments.push(Const.ArgIsTestMode);
+    }
+    if (gameState.muted) {
+      additionalArguments.push(Const.ArgIsInitMuted);
+    }
+    const mainWindowOptions: BrowserWindowConstructorOptions = {
+      useContentSize: true,
+      width: mainWindowSize.width,
+      height: mainWindowSize.height,
+      ...mainWindowPlacement,
+      minWidth: minWidth,
+      minHeight: minHeight,
+      fullscreenable: false,
+      maximizable: false,
+      titleBarStyle: 'hidden',
+      frame: false,
+      resizable: !gameSetting.isAssistInGame,
+      backgroundColor: '#000',
+      webPreferences: {
+        nodeIntegration: true,
+        contextIsolation: false,
+        nodeIntegrationInSubFrames: true,
+        webviewTag: true,
+        spellcheck: false,
+        preload: path.join(__dirname, '../preload/index.js'),
+        additionalArguments,
+        sandbox: false
+        //sandbox: true
+      }
+    }
+    this.main_window = new BrowserWindow(mainWindowOptions)
+
+    // ゲームのみ表示で保存されていたサイズを復元
+    const restoredGameOnlySize = appSetting.restoreGameOnlySize()
+    if (restoredGameOnlySize) {
+      appState.game_only_width = restoredGameOnlySize.width
+      appState.game_only_height = restoredGameOnlySize.height
+    }
+
+    // ゲームページの場合にプリロード指定
+    this.main_window.webContents.on('will-attach-webview', (_event, webPreferences, params) => {
+      debug('will-attach-webview:', params, webPreferences)
+      if (params.src === Const.GamePageUrl) {
+        webPreferences.preload = path.join(getMainDir(), '../preload/xhr-hook.js')
+      }
+    })
+
+    if (Env.isDevelopment) {
+      this.main_window.webContents.openDevTools()
+    }
+
+    appState.media_source_id = this.main_window.getMediaSourceId()
+    debug({
+      'assistRestricted': gameSetting.assistRestricted,
+      main_window_id: this.main_window.id,
+      media_source_id: appState.media_source_id,
+      mainWindowSize: mainWindowSize,
+      mainWindowPos: mainWindowPos,
+      frame_ratio: this.frame_ratio,
+      minWidth,
+      minHeight,
+      'calcFrameRatio:': AppStuff.calcFrameRatio(minWidth, minHeight)
+    })
+
+    debug(
+      'mainWindow pos info', {
+        'getPosition': this.main_window.getPosition(),
+        'getBounds': this.main_window.getBounds(),
+        'getContentBounds': this.main_window.getContentBounds(),
+        'getSize': this.main_window.getSize()
+      }
+    )
+
+    gameSettingProxy.webContents = this.main_window.webContents
+    if (!gameSetting.isAssistInGame) {
+      this.updateGameOnlyZoomFactor()
+    }
+    this.main_window.setAlwaysOnTop(gameSetting.topmost)
+
+    // open app html
+    openAppHtml(this.mainWindow)
+
+    // アシストウインドウを別画面で表示する場合
+    // display要件を満たすディスプレイがない場合はアシストウインドウを別画面で表示する
+    const restoredAssistWindowState = appSetting.restoreAssistWindowState(true)
+    if (restoredAssistWindowState || gameSetting.assistRestricted) {
+      const state = gameSetting.assistRestricted ? undefined : restoredAssistWindowState
+      this.openAssistWindow(state?.position ? { ...state.position, display: state.display } : undefined)
+    }
+
+    // Persist window state before any child windows are closed by the main window shutdown path.
+    this.mainWindow.on('close', () => {
+      if (this.assist_window && !this.assist_window.isDestroyed()) {
+        if (! gameSetting.assistRestricted) {
+          appSetting.updateAssistWindowState(this.assist_window, false)
+        }
+      }
+      this.saveAppState()
+    })
+
+    this.mainWindow.on('closed', () => this.onClosed())
+    this.mainWindow.on('resize', () => this.onResize())
+    this.mainWindow.on('will-resize', (event, newBounds, _details) =>
+      this.onWillResize(event, newBounds)
+    )
+
+    // set intake schedule
+    Intaker.setIntakeSchedule();
+  }
+
+  /**
+   *
+   */
+  private openAssistWindow(position?: { x: number; y: number, display: Display }): void {
+    if (this.assist_window) {
+      // noop
+      return
+    }
+
+    // 表示位置計算
+    const assistWindowPosition = ((): { x: number; y: number, display: Display } => {
+
+      // 位置情報が有効
+      if (position) {
+        return position
+      }
+
+      // 推奨サイズの要件を満たすディスプレイがない場合
+      if (gameSetting.assistRestricted) {
+        // 表示位置保存が無い場合、プライマリディスプレイに表示する
+        // ウインドウはcontentsizeでの作成で実際はフレームサイズ分補正が必要
+        // 補正はウインドウ非表示で作成後に行う
+        const primaryDisplay = screen.getPrimaryDisplay()
+        const bounds = primaryDisplay.workArea
+        const y = Math.max(bounds.y, bounds.y + (bounds.height-Const.InGameAssistDisplayRequirementHeight)/2)
+        // debug('assist window position for restricted:', 
+        //   { x: bounds.x + bounds.width - Const.AssistWidth, y, display: primaryDisplay,
+        //     assistWindowWidth: Const.AssistWidth,
+        //     bounds: bounds
+        //   })
+        return { 
+          x: bounds.x + bounds.width - Const.AssistWidth, 
+          y, 
+          display: primaryDisplay }
+      }
+
+      // 位置情報が無効、メインウインドウの表示位置から空いている領域に表示
+      const mainRect = this.main_window.getNormalBounds();
+      const display = screen.getDisplayMatching(this.main_window.getBounds());
+      const bounds = display.workArea
+      const y = Math.max(bounds.y, bounds.y + (bounds.height-Const.InGameAssistDisplayRequirementHeight)/2)
+
+      // 空き領域判定
+      const intersectRect = RectUtil.intersect(mainRect, bounds)
+      if (! intersectRect) {
+        return { x: mainRect.x + mainRect.width - 100, y, display }
+      }
+
+      const leftSpace = intersectRect.x - bounds.x
+      const rightSpace = bounds.x + bounds.width - (intersectRect.x + intersectRect.width)
+      if (rightSpace >= leftSpace) {
+        return { x: intersectRect.x + intersectRect.width, y, display }
+      } else {
+        return { x: intersectRect.x - Const.AssistWidth, y, display }
+      }
+    })()
+
+    // 表示サイズ計算
+    const assistWindowSize = ((): { width: number; height: number } => {
+      return {
+        width: Const.AssistWidth, 
+        height: Math.min(
+          Const.InGameAssistDisplayRequirementHeight - Const.TitleBarHeight, 
+          assistWindowPosition.display.workArea.height)
+      }
+    })()
+
+    const additionalArguments: string[] = [Const.ArgIsAssist];
+    if (Env.isTestMode) {
+      additionalArguments.push(Const.ArgIsTestMode);
+    }
+
+    debug('assist window info', {
+      assistRestricted: gameSetting.assistRestricted,
+      assistWindowPosition,
+      assistWindowSize,
+      display: assistWindowPosition.display,
+    })
+
+    const iconPath = app.isPackaged 
+      ? path.join(process.resourcesPath, 'resources/app.ico') : path.join(__dirname, '../../resources/app.ico')
+    this.assist_window = new BrowserWindow({
+      title: '甲ブラウザ',
+      icon: iconPath,
+      parent: this.main_window,
+      useContentSize: true,
+      width: assistWindowSize.width,
+      height: assistWindowSize.height,
+      x: assistWindowPosition.x,
+      y: assistWindowPosition.y,
+      show: false,
+      webPreferences: {
+        nodeIntegration: true,
+        contextIsolation: false,
+        nodeIntegrationInSubFrames: true,
+        spellcheck: false,
+        preload: path.join(getMainDir(), '../preload/index.js'),
+        additionalArguments,
+        sandbox: false
+        //sandbox: true
+      }
+    })
+    this.assist_window.setMenu(null)
+
+    // ウインドウ位置とサイズをフレームサイズで補正
+    if (gameSetting.assistRestricted) {
+
+      // 位置補正
+      const contentBounds = this.assist_window.getContentBounds()
+      const windowBounds = this.assist_window.getBounds()
+      const fixX = windowBounds.width - contentBounds.width
+      const fixX2 = Math.trunc(fixX/assistWindowPosition.display.scaleFactor)
+      this.assist_window.setPosition(
+        assistWindowPosition.x - fixX2,
+        assistWindowPosition.y);
+
+      // サイズ補正
+      const workArea = assistWindowPosition.display.workArea
+      if (workArea.height < windowBounds.height) {
+        this.assist_window.setSize(
+          windowBounds.width,
+          workArea.height+Math.max(0, fixX2-2),
+          false
+        )
+      }
+    }
+
+    // 補正後に表示
+    this.assist_window.show()
+
+    this.assist_window.addListener('close', () => {
+      if (! gameSetting.assistRestricted) {
+        // 閉じた位置を保存
+        if (this.assist_window) {
+          appSetting.updateAssistWindowState(this.assist_window, true)
+        }
+      }
+    })
+    this.assist_window.addListener('closed', () => {
+      this.assist_window = null
+    })
+
+    // open app html
+    openAppHtml(this.assist_window)
+
+    if (Env.isDevelopment) {
+      this.assist_window.webContents.openDevTools()
+    }
+  }
+
+  /**
+   * 
+   */
+  private setupHandlers() {
     app.on('web-contents-created', (event, webContents) =>
       this.onWebContentsCreated(event, webContents)
     )
@@ -375,110 +748,6 @@ export class KcApp {
       ipcMain.on(kcsapi_hook.HookedType.unk_loadstart, (_event, data) => this.onApiHookUnknownLoadStart(data));
       ipcMain.on(kcsapi_hook.HookedType.unk_loadend, (_event, data) => this.onApiHookUnknownLoadEnd(data));
     }
-
-    // create main frame
-    const additionalArguments: string[] = [];
-    additionalArguments.push(`--${Const.ArgAppLaunchId}=${appLaunchId}`);
-    if (Env.isTestMode) {
-      additionalArguments.push(Const.ArgIsTestMode);
-    }
-    if (gameState.muted) {
-      additionalArguments.push(Const.ArgIsInitMuted);
-    }
-    const mainWindowOptions: BrowserWindowConstructorOptions = {
-      useContentSize: true,
-      width: withAssistSize.width,
-      height: withAssistSize.height,
-      ...mainWindowPlacement,
-      minWidth: minWidth,
-      minHeight: minHeight,
-      fullscreenable: false,
-      maximizable: false,
-      titleBarStyle: 'hidden',
-      frame: false,
-      resizable: !gameSetting.isAssistInGame,
-      backgroundColor: '#000',
-      webPreferences: {
-        nodeIntegration: true,
-        contextIsolation: false,
-        nodeIntegrationInSubFrames: true,
-        webviewTag: true,
-        spellcheck: false,
-        preload: path.join(__dirname, '../preload/index.js'),
-        additionalArguments,
-        sandbox: false
-        //sandbox: true
-      }
-    }
-    this.main_window = new BrowserWindow(mainWindowOptions)
-    if (restoredGameOnlySize) {
-      appState.game_only_width = restoredGameOnlySize.width
-      appState.game_only_height = restoredGameOnlySize.height
-    }
-
-    this.main_window.webContents.on('will-attach-webview', (_event, webPreferences, params) => {
-      debug('will-attach-webview:', params, webPreferences)
-      if (params.src === Const.GamePageUrl) {
-        webPreferences.preload = path.join(getMainDir(), '../preload/xhr-hook.js')
-      }
-    })
-
-    if (Env.isDevelopment) {
-      this.main_window.webContents.openDevTools()
-    }
-
-    appState.media_source_id = this.main_window.getMediaSourceId()
-    debug(
-      'id, media_source_id, w, h, ratio, minW, minH, minR',
-      this.main_window.id,
-      appState.media_source_id,
-      withAssistSize,
-      this.frame_ratio,
-      minWidth,
-      minHeight,
-      AppStuff.calcFrameRatio(minWidth, minHeight)
-    )
-
-    gameSettingProxy.webContents = this.main_window.webContents
-    if (!gameSetting.isAssistInGame) {
-      this.updateGameOnlyZoomFactor()
-    }
-    this.main_window.setAlwaysOnTop(gameSetting.topmost)
-
-    debug(
-      'mainWindow.getPosition()',
-      this.main_window.getPosition(),
-      this.main_window.getSize()
-    )
-
-    //if (! gameSetting.assist_in_game) {
-    //this.openAssistWindow();
-    //}
-
-    // open app html
-    openAppHtml(this.mainWindow)
-
-    if (restoredAssistWindowState) {
-      this.openAssistWindow(restoredAssistWindowState.position)
-    }
-
-    // Persist window state before any child windows are closed by the main window shutdown path.
-    this.mainWindow.on('close', () => {
-      if (this.assist_window && !this.assist_window.isDestroyed()) {
-        updateAssistWindowState(this.assist_window, false)
-      }
-      this.saveAppState()
-    })
-
-    this.mainWindow.on('closed', () => this.onClosed())
-    this.mainWindow.on('resize', () => this.onResize())
-    this.mainWindow.on('will-resize', (event, newBounds, _details) =>
-      this.onWillResize(event, newBounds)
-    )
-
-
-    // set intake schedule
-    Intaker.setIntakeSchedule();
   }
 
   /**
@@ -567,72 +836,6 @@ export class KcApp {
    */
   private static setCustomMenu(window: BrowserWindow): void {
     window.setMenu(KcApp.buildCustomMenu())
-  }
-
-  /**
-   *
-   */
-  private openAssistWindow(position?: { x: number; y: number }): void {
-    if (this.assist_window) {
-      // noop
-      return
-    }
-
-    //
-    const pos = this.main_window.getPosition()
-    const size = this.main_window.getSize()
-    const defaultPosition = {
-      x: pos[0] + size[0] - 100,
-      y: pos[1]
-    }
-    const assistWindowPosition = position ?? defaultPosition
-    const additionalArguments: string[] = [Const.ArgIsAssist];
-    if (Env.isTestMode) {
-      additionalArguments.push(Const.ArgIsTestMode);
-    }
-
-    const iconPath = app.isPackaged 
-      ? path.join(process.resourcesPath, 'resources/app.ico') : path.join(__dirname, '../../resources/app.ico')
-
-    this.assist_window = new BrowserWindow({
-      title: '甲ブラウザ',
-      icon: iconPath,
-      parent: this.main_window,
-      useContentSize: true,
-      width: Const.AssistWidth,
-      height: size[1] - Const.TitleBarHeight,
-      x: assistWindowPosition.x,
-      y: assistWindowPosition.y,
-      webPreferences: {
-        nodeIntegration: true,
-        contextIsolation: false,
-        nodeIntegrationInSubFrames: true,
-        spellcheck: false,
-        preload: path.join(getMainDir(), '../preload/index.js'),
-        additionalArguments,
-        sandbox: false
-        //sandbox: true
-      }
-    })
-    this.assist_window.setMenu(null)
-
-    debug('assist window id', this.assist_window.id)
-    this.assist_window.addListener('close', () => {
-      // 閉じた位置を保存
-      if (this.assist_window) {
-        updateAssistWindowState(this.assist_window!, true)
-      }
-    })
-    this.assist_window.addListener('closed', () => {
-      this.assist_window = null
-    })
-
-    // open app html
-    openAppHtml(this.assist_window)
-
-    if (Env.isDevelopment) {
-      this.assist_window.webContents.openDevTools()
-    }
   }
 
   // private closeAssistWindow(): void {
@@ -728,9 +931,15 @@ export class KcApp {
     gameSetting.setAssistInGame(show)
     this.mainWindow.setResizable(!gameSetting.isAssistInGame)
 
-    const size = calcAssistWindowSize()
+    const size = calcMainWindowSize(gameSetting.isAssistInGame)
+    debug('resize main window for assist show change', size)
     this.nohandle_resize = true
-    this.mainWindow.setSize(size.width, size.height, false)
+    this.mainWindow.setContentSize(size.width, size.height, false)
+    if (!gameSetting.isAssistInGame) {
+      const { minWidth, minHeight } = calcMainWindowMinSize();
+      this.mainWindow.setMinimumSize(minWidth, minHeight)
+    }
+    debug('resize main window contents size', this.mainWindow.getContentSize())
     if (!gameSetting.isAssistInGame) {
       gameSetting.zoom_factor = AppStuff.calcGameZoomFactor(size.width)
     }
@@ -748,7 +957,7 @@ export class KcApp {
     const size = this.mainWindow.getContentSize()
     appState.game_only_width = size[0]
     appState.game_only_height = size[1]
-    const calcSize = calcAssistWindowSize()
+    const calcSize = calcMainWindowSize(gameSetting.isAssistInGame)
     gameSetting.zoom_factor = AppStuff.calcGameZoomFactor(calcSize.width)
   }
 
@@ -808,7 +1017,7 @@ export class KcApp {
 
     // update assist windows pos
     if (this.assist_window?.isVisible()) {
-      updateAssistWindowState(this.assist_window, false)
+      appSetting.updateAssistWindowState(this.assist_window, false)
     }
 
     this.saveAppState()
@@ -873,8 +1082,8 @@ export class KcApp {
       this.assist_window.show()
       this.assist_window.focus()
     } else {
-      const state = restoreAssistWindowState(false)
-      this.openAssistWindow(state?.position)
+      const state = appSetting.restoreAssistWindowState(false)
+      this.openAssistWindow(state?.position ? { ...state.position, display: state.display } : undefined)
     }
   }
 

--- a/src/renderer/src/components/TitleBar.vue
+++ b/src/renderer/src/components/TitleBar.vue
@@ -416,11 +416,11 @@ const isAssistShown = computed((): boolean => {
 })
 
 const isAssistOk = computed((): boolean => {
-  return gameSetting.assist_ok
+  return !gameSetting.assistRestricted
 })
 
 const onAssist = (): void => {
-  if (!gameSetting.assist_ok) {
+  if (gameSetting.assistRestricted) {
     return
   }
   if (gameSetting.assistInGame) {
@@ -498,7 +498,7 @@ const updateAvailableTitle = computed((): string => {
 
 const onUpdateAvailableClick = (event: MouseEvent): void => {
   event.stopPropagation()
-  if (gameSetting.assist_ok && !gameSetting.assistInGame) {
+  if (! gameSetting.assistRestricted && !gameSetting.assistInGame) {
     window.api.showAssist()
   }
   AssistUIState.requestTab('about')


### PR DESCRIPTION
## Summary
- add restricted startup handling when the target display is too small for the fixed integrated-assist layout
- keep the main window inside the display area and use a separate assist window in restricted mode
- store restricted-mode window state separately from normal app window settings

## Validation
- npm run typecheck:node
- npm run typecheck:web
- npx vitest run src/main/__tests__/app_setting.test.ts
- npm run test

## Notes
- npm run lint was checked earlier but the repository has existing unrelated lint failures.