### PR TITLE
Apply option settings

### DIFF
--- a/src/common/channel.ts
+++ b/src/common/channel.ts
@@ -98,4 +98,5 @@ export const OptionChannel = {
   selectCaptureSavePath: 'option:select-capture-save-path', 
   minimize: 'option:minimize',
   close: 'option:close',
+  saveSetting: 'option:save-setting'
 }

--- a/src/common/option.ts
+++ b/src/common/option.ts
@@ -2,13 +2,13 @@
 // electron default 'system'
 export type ProxyMode = 'direct' | 'auto_detect' | 'pac_script' | 'fixed_servers' | 'system';
 
+/**
+ * オプション画面で設定可能な項目
+ */
 export interface OptionSetting {
 
-  // capture save path
-  captureSavePath: string
-
-  // default capture save path
-  defaultCaptureSavePath: string
+  // capture save path, defult null, if null use defaultCaptureSavePath
+  captureSavePath: string | null
 
   // proxy mode, default 'system'
   proxyMode: ProxyMode
@@ -20,13 +20,36 @@ export interface OptionSetting {
   proxyFixedServers: string | null
 }
 
+/**
+ * オプション画面で設定可能ではなく表示のみの値
+ */
+export interface OptionViewInfo {
+
+  // default capture save path
+  defaultCaptureSavePath: string
+}
+
+/**
+ * オプション画面に渡す情報
+ */
+export interface OptionData {
+  setting: OptionSetting
+  viewInfo: OptionViewInfo
+}
+
 // def or init value
 export function defaultOptionSetting(): OptionSetting {
   return {
-    captureSavePath: '',
-    defaultCaptureSavePath: '',
+    captureSavePath: null,
     proxyMode: 'system',
     proxyPacScript: null,
     proxyFixedServers: null
   }
 }
+
+export const NullableStringOptionKeys = [
+  'proxyPacScript',
+  'proxyFixedServers'
+] as const satisfies readonly (keyof OptionSetting)[]
+
+export type NullableStringOptionKey = (typeof NullableStringOptionKeys)[number]

--- a/src/common/option.ts
+++ b/src/common/option.ts
@@ -7,7 +7,7 @@ export type ProxyMode = 'direct' | 'auto_detect' | 'pac_script' | 'fixed_servers
  */
 export interface OptionSetting {
 
-  // capture save path, defult null, if null use defaultCaptureSavePath
+  // capture save path (default: null). When null, use the app's default capture path.
   captureSavePath: string | null
 
   // proxy mode, default 'system'

--- a/src/main/__tests__/store.test.ts
+++ b/src/main/__tests__/store.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, it } from 'vitest'
+import { mergeStoredData } from '@main/store'
+
+describe('mergeStoredData', () => {
+  it('keeps default object keys that are missing from loaded data', () => {
+    const defaults = {
+      width: 1024,
+      height: 768,
+      theme: 'light'
+    }
+
+    const loaded = {
+      width: 1280
+    }
+
+    expect(mergeStoredData(defaults, loaded)).toEqual({
+      width: 1280,
+      height: 768,
+      theme: 'light'
+    })
+  })
+
+  it('merges nested plain objects recursively', () => {
+    const defaults = {
+      window: {
+        width: 1024,
+        height: 768,
+        position: {
+          x: 10,
+          y: 20
+        }
+      },
+      enabled: true
+    }
+
+    const loaded = {
+      window: {
+        height: 900,
+        position: {
+          y: 30
+        }
+      }
+    }
+
+    expect(mergeStoredData(defaults, loaded)).toEqual({
+      window: {
+        width: 1024,
+        height: 900,
+        position: {
+          x: 10,
+          y: 30
+        }
+      },
+      enabled: true
+    })
+  })
+
+  it('keeps the default value when a loaded object property is undefined', () => {
+    const defaults = {
+      width: 1024,
+      height: 768
+    }
+
+    const loaded = {
+      width: undefined,
+      height: 900
+    }
+
+    expect(mergeStoredData(defaults, loaded)).toEqual({
+      width: 1024,
+      height: 900
+    })
+  })
+
+  it('uses null from loaded object properties as an explicit value', () => {
+    const defaults = {
+      selectedId: 100,
+      nested: {
+        label: 'default',
+        count: 1
+      }
+    }
+
+    const loaded = {
+      selectedId: null,
+      nested: {
+        label: null
+      }
+    }
+
+    expect(mergeStoredData(defaults, loaded)).toEqual({
+      selectedId: null,
+      nested: {
+        label: null,
+        count: 1
+      }
+    })
+  })
+
+  it('replaces arrays instead of merging them', () => {
+    const defaults = {
+      recentFiles: ['a.json', 'b.json'],
+      options: {
+        values: [1, 2, 3]
+      }
+    }
+
+    const loaded = {
+      recentFiles: ['c.json'],
+      options: {
+        values: [4]
+      }
+    }
+
+    expect(mergeStoredData(defaults, loaded)).toEqual({
+      recentFiles: ['c.json'],
+      options: {
+        values: [4]
+      }
+    })
+  })
+
+  it('returns defaults when loaded data is null or undefined', () => {
+    const defaults = {
+      width: 1024
+    }
+
+    expect(mergeStoredData(defaults, null)).toEqual(defaults)
+    expect(mergeStoredData(defaults, undefined)).toEqual(defaults)
+  })
+})

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1,14 +1,69 @@
-import { app, BrowserWindow } from 'electron'
+import { app, BrowserWindow, session } from 'electron'
 import { electronApp, optimizer, is } from '@electron-toolkit/utils'
 import { Const } from '@common/const'
 import { KcApp, getKcApp } from '@main/kcbrowser'
 import *  as workers from '@main/stuff/wrokers'
 import { threadId } from 'worker_threads'
-import { setMainDir } from '@main/path'
+import { PathStuff, setMainDir, setUserDataDir } from '@main/path'
 import { Intaker } from '@main/stuff/intaker'
+import { optionSettingStore } from './store'
+import { defaultOptionSetting, OptionSetting } from '@common/option'
 
 console.log('main index.ts __dirname:', __dirname)
 setMainDir(__dirname)
+
+// set user data dir
+console.log('app dir(user data):', app.getPath('userData'))
+setUserDataDir(app.getPath('userData'))
+
+/**
+ * 
+ * @param setting 
+ */
+async function setProxy(setting: OptionSetting): Promise<void> {
+
+  if (setting.proxyMode === 'system') {
+    await session.defaultSession.setProxy({
+      mode: 'system'
+    })
+  }
+
+  if (setting.proxyMode === 'direct') {
+    await session.defaultSession.setProxy({
+      mode: 'direct'
+    })
+  }
+  
+  if (setting.proxyMode === 'auto_detect') {
+    await session.defaultSession.setProxy({
+      mode: 'auto_detect'
+    })
+  }
+
+  if (setting.proxyMode === 'pac_script') {
+    if (setting.proxyPacScript) {
+      await session.defaultSession.setProxy({
+        mode: 'pac_script',
+        pacScript: setting.proxyPacScript
+      })
+    } else {
+      console.warn('PAC script mode selected but no PAC script URL provided.')
+    }
+  }
+
+  if (setting.proxyMode === 'fixed_servers') {
+    if (setting.proxyFixedServers) {
+      await session.defaultSession.setProxy({
+        mode: 'fixed_servers',
+        proxyRules: setting.proxyFixedServers
+      })
+    } else {
+      console.warn('Fixed servers mode selected but no proxy rules provided.')
+    }
+  }
+
+  await session.defaultSession.closeAllConnections()
+}
 
 // Keep a global reference of the window object, if you don't, the window will
 // be closed automatically when the JavaScript object is garbage collected.
@@ -41,7 +96,7 @@ if (!gotTheLock) {
   // This method will be called when Electron has finished
   // initialization and is ready to create browser windows.
   // Some APIs can only be used after this event occurs.
-  app.whenReady().then(() => {
+  app.whenReady().then(async () => {
     // Set app user model id for windows
     electronApp.setAppUserModelId(Const.AppUserModelId)
 
@@ -51,7 +106,23 @@ if (!gotTheLock) {
     app.on('browser-window-created', (_, window) => {
       optimizer.watchWindowShortcuts(window)
     })
-    
+
+    // load option setting
+    let optionSetting = defaultOptionSetting()
+
+    try {
+      optionSetting = await optionSettingStore.loadAsync(defaultOptionSetting())
+    } catch (err) {
+      console.error('Failed to load option setting. Falling back to default setting.', err)
+    }
+
+    // set capture path
+    PathStuff.setCapturePath(optionSetting.captureSavePath)
+
+    // set proxy
+    await setProxy(optionSetting)
+
+    // create main window
     createWindow()
   })
 }

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -120,7 +120,12 @@ if (!gotTheLock) {
     PathStuff.setCapturePath(optionSetting.captureSavePath)
 
     // set proxy
-    await setProxy(optionSetting)
+    try {
+      await setProxy(optionSetting)
+    } catch (err) {
+      console.error('Failed to apply proxy setting. Falling back to system proxy.', err)
+      await session.defaultSession.setProxy({ mode: 'system' })
+    }
 
     // create main window
     createWindow()

--- a/src/main/kcbrowser.ts
+++ b/src/main/kcbrowser.ts
@@ -49,7 +49,7 @@ import {
 } from '@common/record'
 import { type Spot, type CellInfo, CommonMap } from '@common/map'
 import { Env } from '@common/env'
-import { airbaseSpotStore, appSettingStore, inheritScoreStoreLoader, mapInfoStoreLoader, missionListStoreLoader, questListStoreLoader } from '@main/store'
+import { airbaseSpotStore, appSettingStore, inheritScoreStoreLoader, mapInfoStoreLoader, missionListStoreLoader, optionSettingStore, questListStoreLoader } from '@main/store'
 import { globalSettingStore } from '@main/store'
 import { getMainDir, PathStuff, setUserDataDir } from '@main/path'
 import iconv from 'iconv-lite'
@@ -68,7 +68,7 @@ import { UpdateCheckResult, UpdateStateSnapshot } from '@common/type'
 import * as appSetting from '@main/app_setting'
 import * as RectUtil from '@common/rect_util'
 import crypto from 'node:crypto'
-import { OptionSetting } from '@common/option'
+import { defaultOptionSetting, OptionData, OptionSetting } from '@common/option'
 
 /////////////////////////////////////////////////////////////////////////////////////
 // debug
@@ -299,8 +299,7 @@ export class KcApp {
     // start worker driver
     WorkersStart(getMainDir());
 
-    // set user data dir
-    setUserDataDir(app.getPath('userData'))
+    // load app setting
     appSetting.loadAppJsonSetting()
 
     // set useragent
@@ -838,10 +837,11 @@ export class KcApp {
 
     // option
     ipcMain.handle(OptionChannel.getCurrentSetting, async () => this.onChannelOptionGetCurrentSetting())
-    ipcMain.handle(OptionChannel.readyToShow, async () => this.onChannelOptionReadyToShow())
-    ipcMain.handle(OptionChannel.selectCaptureSavePath, async () => this.onChannelOptionSelectCaptureSavePath())
-    ipcMain.handle(OptionChannel.minimize, async () => this.onChannelOptionMinimize())
-    ipcMain.handle(OptionChannel.close, async () => this.onChannelOptionClose())
+    ipcMain.handle(OptionChannel.readyToShow, () => this.onChannelOptionReadyToShow())
+    ipcMain.handle(OptionChannel.selectCaptureSavePath, () => this.onChannelOptionSelectCaptureSavePath())
+    ipcMain.handle(OptionChannel.minimize, () => this.onChannelOptionMinimize())
+    ipcMain.handle(OptionChannel.close, () => this.onChannelOptionClose())
+    ipcMain.handle(OptionChannel.saveSetting, (_event, data) => this.onChannelOptionSaveSetting(data))
   }
 
   /**
@@ -1188,22 +1188,18 @@ export class KcApp {
   /**
    * 
    */
-  private getCurrentOptionSetting(): OptionSetting {
-    return {
-      captureSavePath: PathStuff.capturePath(false),
-      defaultCaptureSavePath: PathStuff.defaultCapturePath,
-      proxyMode: 'system',
-      proxyPacScript: null,
-      proxyFixedServers: null,
-    }
-  }
-
-  /**
-   * 
-   */
-  private async onChannelOptionGetCurrentSetting(): Promise<OptionSetting> {
+  private onChannelOptionGetCurrentSetting(): Promise<OptionData> {
     debug(OptionChannel.getCurrentSetting)
-    return this.getCurrentOptionSetting()
+    return new Promise<OptionData>((resolve, reject) => {
+      optionSettingStore.load(defaultOptionSetting(), (data) => {
+        resolve({
+          setting: data,
+          viewInfo: {
+            defaultCaptureSavePath: PathStuff.defaultCapturePath
+          }
+        })
+      }, (err) => reject(err))
+    });
   }
 
   /**
@@ -1258,6 +1254,17 @@ export class KcApp {
     if (this.option_window && !this.option_window.isDestroyed()) {
       this.option_window.close()
     }
+  }
+
+  /**
+   * 
+   */
+  private onChannelOptionSaveSetting(setting: OptionSetting): void {
+    debug(OptionChannel.saveSetting, setting)
+    optionSettingStore.save(setting)
+
+    // キャプチャ保存先更新する
+    PathStuff.setCapturePath(setting.captureSavePath)
   }
 
   /**

--- a/src/main/path.ts
+++ b/src/main/path.ts
@@ -113,7 +113,7 @@ class PathStuffImpl {
   capturePath(createIf: boolean): string {
     const ret = this.getCapturePath()
     if (createIf && !fs.existsSync(ret)) {
-      fs.mkdirSync(ret)
+      fs.mkdirSync(ret, { recursive: true })
     }
 
     return ret

--- a/src/main/path.ts
+++ b/src/main/path.ts
@@ -53,6 +53,13 @@ export interface AppMapDrawed {
  *
  */
 class PathStuffImpl {
+
+  /**
+   * ユーザ指定キャプチャパス
+   * 設定なしの時null
+   */
+  private capturePath_: string | null = null
+
   /**
    *
    */
@@ -90,15 +97,30 @@ class PathStuffImpl {
   }
 
   /**
+   * 
+   */
+  private getCapturePath(): string {
+    if (this.capturePath_) {
+      return this.capturePath_
+    } else {
+      return this.defaultCapturePath
+    }
+  }
+
+  /**
    *
    */
   capturePath(createIf: boolean): string {
-    const ret = path.join(getUserDataDir(), capture_dirname)
+    const ret = this.getCapturePath()
     if (createIf && !fs.existsSync(ret)) {
       fs.mkdirSync(ret)
     }
 
     return ret
+  }
+
+  public setCapturePath(path: string | null): void {
+    this.capturePath_ = path
   }
 
   /**

--- a/src/main/store.ts
+++ b/src/main/store.ts
@@ -6,6 +6,7 @@ import { CommonMap } from '@common/map'
 import { AppSetting, defaultAppSetting, InheritScoreList } from '@common/store'
 import { GlobalSetting } from '@common/global_setting'
 import { ApiMapInfoList, ApiMissionList, ApiQuestList } from '@common/kcs'
+import { OptionSetting } from '@common/option'
 
 /**
  *
@@ -101,7 +102,7 @@ function isPlainObject(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value)
 }
 
-function mergeStoredData<T>(defaults: T, loaded: unknown): T {
+export function mergeStoredData<T>(defaults: T, loaded: unknown): T {
   if (!isPlainObject(defaults) || !isPlainObject(loaded)) {
     return (loaded ?? defaults) as T
   }
@@ -162,6 +163,22 @@ class JsonStoreLoader<T extends Object> {
     } else {
       // call loaded callback with def value
       cb(def)
+    }
+  }
+
+  async loadAsync(def: T): Promise<T> {
+    const filepath = this.storePath
+
+    if (!fs.existsSync(filepath)) {
+      return def
+    }
+
+    try {
+      const fileContents = await fs.promises.readFile(filepath, 'utf8')
+      return mergeStoredData(def, JSON.parse(fileContents))
+    } catch (err: any) {
+      console.error(err)
+      throw err
     }
   }
 
@@ -267,6 +284,9 @@ export const appSettingStore = new JsonStore<AppSetting>(
 
 export const globalSettingStore = new JsonStoreLoader<GlobalSetting>(
   'global.json', () => PathStuff.storeGlobal);
+
+export const optionSettingStore = new JsonStoreLoader<OptionSetting>(
+  'option.json', () => PathStuff.storeGlobal);
 
 export const inheritScoreStoreLoader = new JsonStoreLoader<InheritScoreList>(
   'inherit_score.json');

--- a/src/preload/option-api-def.d.ts
+++ b/src/preload/option-api-def.d.ts
@@ -1,9 +1,10 @@
 export interface OptionApi {
-  getCurrentSetting(): Promise<OptionSetting>
+  getCurrentSetting(): Promise<OptionInitialData>
   readyToShow(): Promise<void>
   selectCaptureSavePath(): Promise<string | null>
   minimize(): Promise<void>
   close(): Promise<void>
+  saveSetting(setting: OptionSetting): Promise<void>
 }
 
 declare global {

--- a/src/preload/option-api.ts
+++ b/src/preload/option-api.ts
@@ -1,10 +1,10 @@
 import { contextBridge, ipcRenderer } from 'electron'
 import { OptionChannel } from '@common/channel'
-import { OptionSetting } from '@common/option'
+import { type OptionSetting, type OptionData } from '@common/option'
 import { type OptionApi } from './option-api-def'
 
 const optionApi: OptionApi = {
-  getCurrentSetting(): Promise<OptionSetting> {
+  getCurrentSetting(): Promise<OptionData> {
     return ipcRenderer.invoke(OptionChannel.getCurrentSetting)
   },
   readyToShow(): Promise<void> {
@@ -18,6 +18,9 @@ const optionApi: OptionApi = {
   },
   close(): Promise<void> {
     return ipcRenderer.invoke(OptionChannel.close)
+  },
+  saveSetting(setting: OptionSetting): Promise<void> {
+    return ipcRenderer.invoke(OptionChannel.saveSetting, setting)
   }
 }
 

--- a/src/renderer/src/assets/option.scss
+++ b/src/renderer/src/assets/option.scss
@@ -355,6 +355,16 @@ input {
       background: #263142;
     }
   }
+
+  &:disabled {
+    color: #6f7b8d;
+    background: #1a1f2a;
+    border-color: #2b3140;
+    cursor: default;
+    &:hover {
+      background: #1a1f2a;
+    }
+  }
 }
 
 .option-row-subdescription {
@@ -366,10 +376,9 @@ input {
 
 .option-row-vertical {
   display: block;
-}
-
-.option-row-vertical .option-path-control {
-  margin-top: 0.5rem;
+  .option-path-control {
+    margin-top: 0.5rem;
+  }
 }
 
 
@@ -417,10 +426,10 @@ input {
   background: #2f5f95;
   border: 1px solid #4474aa;
   border-radius: 6px;
-}
-
-.option-error-close-button:hover {
-  background: #386fae;
+  
+  &:hover {
+    background: #386fae;
+  }
 }
 
 
@@ -438,10 +447,10 @@ input {
   width: fit-content;
   color: #d9dee7;
   font-size: 13px;
-}
-
-.option-radio input {
-  margin: 0;
+  
+  input {
+    margin: 0;
+  }
 }
 
 .option-sub-control {
@@ -451,19 +460,87 @@ input {
 
 .option-text-input {
   width: 100%;
-  height: 32px;
+  height: 1.75rem;
   padding: 0 10px;
   color: #e6ebf3;
   background: #1c2230;
   border: 1px solid #343c4d;
-  border-radius: 5px;
+  //border-radius: 5px;
+  
+  &::placeholder {
+    color: #6f7b8d;
+  }
+  
+  &:focus {
+    outline: none;
+    border-color: #4474aa;
+  }
+  
+  &:disabled {
+    color: #6f7b8d;
+    background: #171b23;
+    border-color: #2b3140;
+    cursor: default;
+    opacity: 1;
+    &::placeholder {
+      color: #4f5a6a;
+    }
+  }
 }
 
-.option-text-input::placeholder {
-  color: #6f7b8d;
+.option-input-clearable {
+  position: relative;
+  width: 100%;
+
+  &:focus-within .option-input-clear-button {
+    display: block;
+  }
 }
 
-.option-text-input:focus {
-  outline: none;
-  border-color: #4474aa;
+.option-input-clear-button {
+  position: absolute;
+  top: 50%;
+  right: 0.5rem;
+  $size: 1.4rem;
+  width: $size;
+  height: $size;
+  padding: 0;
+  color: #c5ccda;
+  line-height: $size;
+  text-align: center;
+  background: #343c4d;
+  border: 0;
+  border-radius: 50%;
+  transform: translateY(-50%);
+  
+  &:hover {
+    color: #fff;
+    background: #4474aa;
+  }
+
+  display: none;
+}
+
+
+.option-radio-with-description {
+  align-items: flex-start;
+  input {
+    margin-top: 0.25rem;
+  }
+}
+
+.option-radio-body {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.option-radio-title {
+  color: #d9dee7;
+}
+
+.option-radio-description {
+  color: #8f9bad;
+  font-size: 0.75rem;
+  line-height: 1.4;
 }

--- a/src/renderer/src/option/components/OptionApp.vue
+++ b/src/renderer/src/option/components/OptionApp.vue
@@ -2,7 +2,7 @@
 import { computed, nextTick, ref, watch } from 'vue'
 import OptionTitleBar from './OptionTitleBar.vue'
 import { optionSetting, optionViewInfo } from '@option/store/optionSetting'
-import { NullableStringOptionKey } from '@common/option.js';
+import type { NullableStringOptionKey } from '@common/option'
 
 // 何らかの要因で設定が読み取れないときはエラー状態とし閉じるのみ可能とする
 const props = withDefaults(

--- a/src/renderer/src/option/components/OptionApp.vue
+++ b/src/renderer/src/option/components/OptionApp.vue
@@ -1,7 +1,8 @@
 <script setup lang="ts">
-import { computed, ref } from 'vue'
+import { computed, nextTick, ref, watch } from 'vue'
 import OptionTitleBar from './OptionTitleBar.vue'
-import { optionSetting } from '@option/store/optionSetting'
+import { optionSetting, optionViewInfo } from '@option/store/optionSetting'
+import { NullableStringOptionKey } from '@common/option.js';
 
 // 何らかの要因で設定が読み取れないときはエラー状態とし閉じるのみ可能とする
 const props = withDefaults(
@@ -60,25 +61,71 @@ const close = (): void => {
 
 ///////////////////////////////////////////////////////////////
 // option - path
-const captureSavePath = ref(optionSetting.captureSavePath)
-const defaultCaptureSavePath = ref(optionSetting.defaultCaptureSavePath)
 const selectCaptureSavePath = (): void => {
   window.optionApi.selectCaptureSavePath().then((path => {
     if (path) {
-      captureSavePath.value = path
+      optionSetting.captureSavePath = path
     }
   }))
 }
 
 const resetCaptureSavePath = (): void => {
-  captureSavePath.value = defaultCaptureSavePath.value
+  optionSetting.captureSavePath = null
 }
+
+const isCaptureSavePathDefault = computed(() => {
+  return ! optionSetting.captureSavePath
+})
 
 ///////////////////////////////////////////////////////////////
 // option - proxy
-const proxyMode = ref(optionSetting.proxyMode)
-const proxyPacScript = ref(optionSetting.proxyPacScript ?? '')
-const proxyFixedServers = ref(optionSetting.proxyFixedServers ?? '')
+function nullableStringInput(key: NullableStringOptionKey) {
+  return computed({
+    get: () => optionSetting[key] ?? '',
+    set: (value: string) => {
+      const trimmed = value.trim()
+      optionSetting[key] = trimmed === '' ? null : trimmed
+    }
+  })
+}
+const proxyPacScriptInput = nullableStringInput('proxyPacScript')
+const proxyFixedServersInput = nullableStringInput('proxyFixedServers')
+const proxyPacScriptInputRef = ref<HTMLInputElement | null>(null)
+const proxyFixedServersInputRef = ref<HTMLInputElement | null>(null)
+
+watch(
+  () => optionSetting.proxyMode,
+  async (mode) => {
+    await nextTick()
+
+    if (mode === 'pac_script') {
+      proxyPacScriptInputRef.value?.focus()
+    } else if (mode === 'fixed_servers') {
+      proxyFixedServersInputRef.value?.focus()
+    }
+  }
+)
+
+const hasProxyPacScriptInput = ref(Boolean(optionSetting.proxyPacScript))
+const hasProxyFixedServersInput = ref(Boolean(optionSetting.proxyFixedServers))
+
+const onProxyPacScriptInput = (event: Event): void => {
+  hasProxyPacScriptInput.value = (event.target as HTMLInputElement).value !== ''
+}
+
+const clearProxyPacScriptInput = (): void => {
+  optionSetting.proxyPacScript = null
+  hasProxyPacScriptInput.value = false
+}
+
+const onProxyFixedServersInput = (event: Event): void => {
+  hasProxyFixedServersInput.value = (event.target as HTMLInputElement).value !== ''
+}
+
+const clearProxyFixedServersInput = (): void => {
+  optionSetting.proxyFixedServers = null
+  hasProxyFixedServersInput.value = false
+}
 
 </script>
 
@@ -135,14 +182,14 @@ const proxyFixedServers = ref(optionSetting.proxyFixedServers ?? '')
                 <span class="option-row-title">スクリーンショット・録画保存フォルダ</span>
                 <span class="option-row-description">スクリーンショットと録画の保存先フォルダを指定します。</span>
                 <span class="option-row-subdescription">
-                  既定値: <span class="selectable">{{ defaultCaptureSavePath }}</span>
+                  既定値: <span class="selectable">{{ optionViewInfo.defaultCaptureSavePath }}</span>
                 </span>
               </span>
               <div class="option-path-control">
                 <input
                   class="option-path-input"
                   type="text"
-                  :value="captureSavePath"
+                  :value="optionSetting.captureSavePath ?? ''"
                   readonly
                   aria-label="スクリーンショットと録画の保存先フォルダ"
                   placeholder="保存先フォルダを選択"
@@ -150,7 +197,10 @@ const proxyFixedServers = ref(optionSetting.proxyFixedServers ?? '')
                 <button class="option-path-button" type="button" @click="selectCaptureSavePath">
                   参照
                 </button>
-                <button class="option-path-button secondary" type="button" @click="resetCaptureSavePath">
+                <button class="option-path-button secondary" 
+                  type="button" 
+                  :disabled="isCaptureSavePathDefault"
+                  @click="resetCaptureSavePath">
                   既定値に戻す
                 </button>
               </div>
@@ -165,54 +215,93 @@ const proxyFixedServers = ref(optionSetting.proxyFixedServers ?? '')
               <div>
                 <div class="option-row-title">プロキシの使用方法</div>
                 <div class="option-row-description">
-                  アプリ内通信に使用するプロキシ設定を指定します。
+                  アプリ内通信に使用するプロキシ設定を指定します。変更は甲ブラウザ再起動後に反映されます。
                 </div>
               </div>
 
               <div class="option-radio-group">
                 <label class="option-radio">
-                  <input v-model="proxyMode" type="radio" value="system" />
+                  <input v-model="optionSetting.proxyMode" type="radio" value="system" />
                   <span>システム設定を使用 (規定値)</span>
                 </label>
 
                 <label class="option-radio">
-                  <input v-model="proxyMode" type="radio" value="direct" />
+                  <input v-model="optionSetting.proxyMode" type="radio" value="direct" />
                   <span>プロキシを使用しない</span>
                 </label>
 
                 <label class="option-radio">
-                  <input v-model="proxyMode" type="radio" value="auto_detect" />
+                  <input v-model="optionSetting.proxyMode" type="radio" value="auto_detect" />
                   <span>自動検出</span>
                 </label>
 
-                <label class="option-radio">
-                  <input v-model="proxyMode" type="radio" value="pac_script" />
-                  <span>PAC スクリプトを使用</span>
+                <label class="option-radio option-radio-with-description">
+                  <input v-model="optionSetting.proxyMode" type="radio" value="pac_script" />
+
+                  <span class="option-radio-body">
+                    <span class="option-radio-title">PAC スクリプトを使用</span>
+                    <span class="option-radio-description">
+                      <span>サポートプロトコル: http, https, data 未サポートプロトコル: file</span>
+                    </span>
+                    <span class="option-radio-description">
+                      設定例(http): <span class="selectable">http://localhost:8080/proxy.pac</span>
+                    </span>
+                    <span class="option-radio-description">
+                      設定例(data): <span class="selectable">data:application/x-ns-proxy-autoconfig,xxxxx</span>
+                    </span>
+                  </span>
+
                 </label>
 
-                <div class="option-sub-control">
+                <div class="option-input-clearable">
                   <input
-                    v-model="proxyPacScript"
+                    ref="proxyPacScriptInputRef"
+                    v-model.lazy="proxyPacScriptInput"
                     class="option-text-input"
                     type="url"
-                    placeholder="例: http://localhost:8191/proxy.pac"
+                    placeholder="例: http://localhost:8080/proxy.pac"
                     aria-label="PAC スクリプト URL"
+                    :disabled="optionSetting.proxyMode !== 'pac_script'"
+                    @input="onProxyPacScriptInput"
                   />
+                  <button
+                    v-if="hasProxyPacScriptInput"
+                    class="option-input-clear-button"
+                    type="button"
+                    aria-label="PAC スクリプト URL をクリア"
+                    @click="clearProxyPacScriptInput"
+                  >&#10005;</button>
                 </div>
 
-                <label class="option-radio">
-                  <input v-model="proxyMode" type="radio" value="fixed_servers" />
-                  <span>固定プロキシサーバーを使用</span>
+                <label class="option-radio option-radio-with-description">
+                  <input v-model="optionSetting.proxyMode" type="radio" value="fixed_servers" />
+
+                  <span class="option-radio-body">
+                    <span class="option-radio-title">固定プロキシサーバーを使用</span>
+                    <span class="option-radio-description">
+                      設定例: <span class="selectable">http=localhost:40620;https=localhost:40620</span>
+                    </span>
+                  </span>
                 </label>
 
-                <div class="option-sub-control">
+                <div class="option-input-clearable">
                   <input
-                    v-model="proxyFixedServers"
+                    ref="proxyFixedServersInputRef"
+                    v-model.lazy="proxyFixedServersInput"
                     class="option-text-input"
                     type="text"
-                    placeholder="例: http=host:8080;https=host:8080"
+                    placeholder="例: http=localhost:40620;https=localhost:40620"
                     aria-label="固定プロキシサーバー"
+                    :disabled="optionSetting.proxyMode !== 'fixed_servers'"
+                    @input="onProxyFixedServersInput"
                   />
+                  <button
+                    v-if="hasProxyFixedServersInput"
+                    class="option-input-clear-button"
+                    type="button"
+                    aria-label="固定プロキシサーバーをクリア"
+                    @click="clearProxyFixedServersInput"
+                  >&#10005;</button>
                 </div>
               </div>
             </div>

--- a/src/renderer/src/option/option.ts
+++ b/src/renderer/src/option/option.ts
@@ -1,22 +1,27 @@
 import { createApp } from 'vue'
 import 'bulma/css/bulma.min.css'
+import '@assets/option.scss'
 
 import OptionApp from '@option/components/OptionApp.vue'
-import '@assets/option.scss'
-import { setOptionSetting } from '@option/store/optionSetting'
-import { type OptionSetting, defaultOptionSetting } from '@common/option'
+import { setOptionSettingWithPreventSave } from '@option/store/optionSetting'
+import { type OptionData, defaultOptionSetting } from '@common/option'
 
 async function main(): Promise<void> {
-  let setting: OptionSetting
+  let data: OptionData
   let isError = false
   try {
-    setting = await window.optionApi.getCurrentSetting()
+    data = await window.optionApi.getCurrentSetting()
   } catch (error) {
     console.error('Failed to get current setting:', error)
-    setting = defaultOptionSetting()
+    data = {
+      setting: defaultOptionSetting(),
+      viewInfo: {
+        defaultCaptureSavePath: ''
+      }
+    }
     isError = true
   }
-  setOptionSetting(setting)
+  setOptionSettingWithPreventSave(data)
 
   createApp(OptionApp, { isError }).mount('#option-app')
   await window.optionApi.readyToShow()

--- a/src/renderer/src/option/store/optionSetting.ts
+++ b/src/renderer/src/option/store/optionSetting.ts
@@ -67,5 +67,5 @@ export function setOptionSettingWithPreventSave(data: OptionData) {
   // set view info
   Object.assign(optionViewInfo, data.viewInfo)
 
-  console.log('set prevent save << preventSave:', preventSave, data)
+  debug('set prevent save << preventSave:', preventSave, data)
 }

--- a/src/renderer/src/option/store/optionSetting.ts
+++ b/src/renderer/src/option/store/optionSetting.ts
@@ -1,8 +1,71 @@
-import { type OptionSetting, defaultOptionSetting } from '@common/option'
-export const optionSetting: OptionSetting = defaultOptionSetting()
+import { reactive, toRaw, watch, ref } from 'vue'
+import { OptionData, type OptionSetting, type OptionViewInfo, defaultOptionSetting } from '@common/option'
+export const optionSetting: OptionSetting = reactive(
+  defaultOptionSetting()
+)
 
-export function setOptionSetting(setting: OptionSetting): void {
-  // 必要ならstructuredClone()に変更する
-  // 現状浅いコピーで良い
-  Object.assign(optionSetting, setting)
+// 画面から値が更新されないことから、OptionViewInfoはreactiveにしない
+export const optionViewInfo: OptionViewInfo = {
+  defaultCaptureSavePath: ''
+} 
+
+/////////////////////////////////////////////////////////////////////////////////////
+// デバッグログ
+const DEBUG = 0;
+
+const debug = (...args: any[]) => {
+  if (DEBUG) console.debug("[Store/OptionSetting]", ...args);
+};
+
+/////////////////////////////////////////////////////////////////////////////////////
+// 
+let preventSave = false;
+
+// 更新抑止フラグ解除のために強制でwatchを呼び出すためのref
+const forWatchCall = ref(0)
+
+const syncHandle = watch(
+  () => [optionSetting, forWatchCall.value],
+  () => {
+    debug('setting changed >> prevent save:', preventSave, optionSetting)
+    if (preventSave) {
+      preventSave = false;
+    } else {
+      window.optionApi.saveSetting(toRaw(optionSetting))
+    }
+    debug('setting changed << ')
+  },
+  { 
+    deep: true,
+    // DOM更新前にwatch実施
+    // 更新抑止動作がおかしくなることからsyncは指定しないこと
+    flush: 'pre'
+  }
+)
+
+/**
+ * 更新抑止動作説明
+ * watch()は同じ値を更新した場合呼ばれない
+ * forWatchCallを更新することで強制でwatch()を呼ぶ
+ * watch()を強制で呼び出すことで更新抑止フラグを解除する
+ * 
+ * forWatchCall更新によりwatch()呼び出しが行われることから
+ * syncHandle.pause()、syncHandle.resume()によりsetting自体のwatch()呼び出しを抑止する
+ * 
+ * @param setting 
+ */
+export function setOptionSettingWithPreventSave(data: OptionData) {
+  debug('set prevent save >> preventSave:', preventSave, data)
+  preventSave = true;
+  forWatchCall.value++;
+
+  // set setting
+  syncHandle.pause()
+  Object.assign(optionSetting, data.setting)
+  syncHandle.resume()
+
+  // set view info
+  Object.assign(optionViewInfo, data.viewInfo)
+
+  console.log('set prevent save << preventSave:', preventSave, data)
 }


### PR DESCRIPTION
## Summary
- option 設定の適用用 IPC と保存処理を追加
- option 画面側の設定状態管理と表示を更新
- `mergeStoredData` の単体テストを追加

## Validation
- npm run test -- src/main/__tests__/store.test.ts
- npm run typecheck