### PR TITLE
Add extension option settings

### DIFF
--- a/src/common/channel.ts
+++ b/src/common/channel.ts
@@ -96,6 +96,7 @@ export const OptionChannel = {
   getCurrentSetting: 'option:get-current-setting',
   readyToShow: 'option:ready-to-show',
   selectCaptureSavePath: 'option:select-capture-save-path', 
+  selectExtensionPath: 'option:select-extension-path',
   minimize: 'option:minimize',
   close: 'option:close',
   saveSetting: 'option:save-setting'

--- a/src/common/option.ts
+++ b/src/common/option.ts
@@ -18,6 +18,16 @@ export interface OptionSetting {
 
   // proxy fixed servers, default null
   proxyFixedServers: string | null
+
+  // unpacked extension information, default empty
+  extensions: ExtensionInfo[]
+}
+
+/**
+ * パッケージ化されていない拡張機能の情報
+ */
+export interface ExtensionInfo {
+  path: string
 }
 
 /**
@@ -43,7 +53,8 @@ export function defaultOptionSetting(): OptionSetting {
     captureSavePath: null,
     proxyMode: 'system',
     proxyPacScript: null,
-    proxyFixedServers: null
+    proxyFixedServers: null,
+    extensions: []
   }
 }
 

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -65,6 +65,22 @@ async function setProxy(setting: OptionSetting): Promise<void> {
   await session.defaultSession.closeAllConnections()
 }
 
+/**
+ *
+ * @param setting
+ */
+async function loadUnpackedExtension(setting: OptionSetting): Promise<void> {
+  for (const extension of setting.extensions) {
+    try {
+      await session.defaultSession.extensions.loadExtension(extension.path, {
+        allowFileAccess: true
+      })
+    } catch (err) {
+      console.error('Failed to load unpacked extension.', extension.path, err)
+    }
+  }
+}
+
 // Keep a global reference of the window object, if you don't, the window will
 // be closed automatically when the JavaScript object is garbage collected.
 let win: BrowserWindow | null
@@ -126,6 +142,9 @@ if (!gotTheLock) {
       console.error('Failed to apply proxy setting. Falling back to system proxy.', err)
       await session.defaultSession.setProxy({ mode: 'system' })
     }
+
+    // load unpacked extension
+    await loadUnpackedExtension(optionSetting)
 
     // create main window
     createWindow()

--- a/src/main/kcbrowser.ts
+++ b/src/main/kcbrowser.ts
@@ -839,6 +839,7 @@ export class KcApp {
     ipcMain.handle(OptionChannel.getCurrentSetting, async () => this.onChannelOptionGetCurrentSetting())
     ipcMain.handle(OptionChannel.readyToShow, () => this.onChannelOptionReadyToShow())
     ipcMain.handle(OptionChannel.selectCaptureSavePath, () => this.onChannelOptionSelectCaptureSavePath())
+    ipcMain.handle(OptionChannel.selectExtensionPath, () => this.onChannelOptionSelectExtensionPath())
     ipcMain.handle(OptionChannel.minimize, () => this.onChannelOptionMinimize())
     ipcMain.handle(OptionChannel.close, () => this.onChannelOptionClose())
     ipcMain.handle(OptionChannel.saveSetting, (_event, data) => this.onChannelOptionSaveSetting(data))
@@ -1229,6 +1230,27 @@ export class KcApp {
       this.option_window, {
       title: 'キャプチャ保存先フォルダを選択',
       properties: ['openDirectory', 'createDirectory']
+    })
+    if (result && result.length > 0) {
+      return result[0]
+    }
+    return null
+  }
+
+  /**
+   *
+   */
+  private onChannelOptionSelectExtensionPath(): string | null {
+    debug(OptionChannel.selectExtensionPath)
+    if (!this.option_window || this.option_window.isDestroyed()) {
+      // noop
+      return null
+    }
+
+    const result = dialog.showOpenDialogSync(
+      this.option_window, {
+      title: '読み込む拡張機能フォルダを選択',
+      properties: ['openDirectory']
     })
     if (result && result.length > 0) {
       return result[0]

--- a/src/preload/option-api-def.d.ts
+++ b/src/preload/option-api-def.d.ts
@@ -2,6 +2,7 @@ export interface OptionApi {
   getCurrentSetting(): Promise<OptionData>
   readyToShow(): Promise<void>
   selectCaptureSavePath(): Promise<string | null>
+  selectExtensionPath(): Promise<string | null>
   minimize(): Promise<void>
   close(): Promise<void>
   saveSetting(setting: OptionSetting): Promise<void>

--- a/src/preload/option-api.ts
+++ b/src/preload/option-api.ts
@@ -13,6 +13,9 @@ const optionApi: OptionApi = {
   selectCaptureSavePath(): Promise<string | null> {
     return ipcRenderer.invoke(OptionChannel.selectCaptureSavePath)
   },
+  selectExtensionPath(): Promise<string | null> {
+    return ipcRenderer.invoke(OptionChannel.selectExtensionPath)
+  },
   minimize(): Promise<void> {
     return ipcRenderer.invoke(OptionChannel.minimize)
   },

--- a/src/renderer/src/option/components/OptionApp.vue
+++ b/src/renderer/src/option/components/OptionApp.vue
@@ -14,7 +14,7 @@ const props = withDefaults(
   }
 )
 
-type CategoryKey = 'general' | 'network';
+type CategoryKey = 'general' | 'network' | 'extension';
 interface CategoryInfo {
   readonly key: CategoryKey
   readonly title: string
@@ -31,6 +31,11 @@ const categories: CategoryInfo[] = [
     key: 'network',
     title: '通信設定',
     description: 'プロキシや通信動作に関する設定'
+  },
+  {
+    key: 'extension',
+    title: '拡張機能',
+    description: '拡張機能に関する設定'
   },
   // {
   //   key: 'assist',
@@ -75,6 +80,26 @@ const resetCaptureSavePath = (): void => {
 
 const isCaptureSavePathDefault = computed(() => {
   return ! optionSetting.captureSavePath
+})
+
+///////////////////////////////////////////////////////////////
+// option - extension
+const extensionPath = computed(() => optionSetting.extensions[0]?.path ?? '')
+
+const selectExtensionPath = (): void => {
+  window.optionApi.selectExtensionPath().then((path => {
+    if (path) {
+      optionSetting.extensions = [{ path }]
+    }
+  }))
+}
+
+const resetExtensionPath = (): void => {
+  optionSetting.extensions = []
+}
+
+const isExtensionPathDefault = computed(() => {
+  return optionSetting.extensions.length === 0
 })
 
 ///////////////////////////////////////////////////////////////
@@ -303,6 +328,38 @@ const clearProxyFixedServersInput = (): void => {
                     @click="clearProxyFixedServersInput"
                   >&#10005;</button>
                 </div>
+              </div>
+            </div>
+          </section>
+
+          <!-- 拡張機能 -->
+          <section v-if="isCurrentCategory('extension')" class="option-section">
+            <div class="section-title">読み込み設定</div>
+            <div class="option-row option-row-vertical">
+              <span>
+                <span class="option-row-title">拡張機能フォルダ</span>
+                <span class="option-row-description">
+                  読み込むパッケージ化されていない拡張機能のフォルダを指定します。変更は甲ブラウザ再起動後に反映されます。
+                </span>
+              </span>
+              <div class="option-path-control">
+                <input
+                  class="option-path-input"
+                  type="text"
+                  :value="extensionPath"
+                  readonly
+                  aria-label="読み込む拡張機能フォルダ"
+                  placeholder="拡張機能フォルダを選択"
+                />
+                <button class="option-path-button" type="button" @click="selectExtensionPath">
+                  参照
+                </button>
+                <button class="option-path-button secondary"
+                  type="button"
+                  :disabled="isExtensionPathDefault"
+                  @click="resetExtensionPath">
+                  クリア
+                </button>
               </div>
             </div>
           </section>


### PR DESCRIPTION
## Summary
- option 設定に「拡張機能」カテゴリを追加
- パッケージ化されていない拡張機能フォルダを1件指定できる設定を追加
- 保存された拡張機能設定を起動時に読み込む処理を追加

## Validation
- npm run typecheck