### PR TITLE
add taiha singeki block

### DIFF
--- a/src/common/channel.ts
+++ b/src/common/channel.ts
@@ -65,7 +65,8 @@ export const GameChannel = {
   set_app_state: 'set_app_state',
   set_game_setting: 'set_game_setting',
   set_zoom_factor: 'set-zoom-factor',
-  resume: 'resume'
+  resume: 'resume',
+  set_ctrl_state: 'set_ctrl_state', // ctrlキー押下状態 args: 押下状態
 } as const
 export type GameChannel = (typeof GameChannel)[keyof typeof GameChannel]
 

--- a/src/common/kcquest.ts
+++ b/src/common/kcquest.ts
@@ -3224,7 +3224,9 @@ register(
       }
 
       const msts = toShipMsts(svdata, ship_ids)
-      const shipIds1 = [
+      const shipIds = [
+        svdata.shipMstIds(1041), // hanaduki
+        svdata.shipMstIds(1044), // kiri
         svdata.shipMstIds(994), // kaya
         svdata.shipMstIds(992), // sugi
         svdata.shipMstIds(993), // kasi
@@ -3232,16 +3234,7 @@ register(
         svdata.shipMstIds(16), // usio
         svdata.shipMstIds(35), // hibiki
       ].flat()
-      // 6月
-      const shipIdsMonth6 = [
-        svdata.shipMstIds(41), // hatusimo
-        svdata.shipMstIds(20), // yukikaze
-        svdata.shipMstIds(533), // fuyutuki
-        svdata.shipMstIds(532), // sudutuki
-      ].flat()
-
-      const shipIds = [...shipIds1]
-      shipIds.push(...shipIdsMonth6)
+      
       return shipCount(msts, shipIds) >= 5
     }
   }

--- a/src/common/kcquest.ts
+++ b/src/common/kcquest.ts
@@ -3234,7 +3234,7 @@ register(
         svdata.shipMstIds(16), // usio
         svdata.shipMstIds(35), // hibiki
       ].flat()
-      
+
       return shipCount(msts, shipIds) >= 5
     }
   }
@@ -7170,7 +7170,10 @@ register(
         ApiShipCategory.richelieu,
         ApiShipCategory.commandantTeste,
         ApiShipCategory.la_galissonniere,
-        ApiShipCategory.mogador
+        ApiShipCategory.mogador,
+        ApiShipCategory.algérie,
+        ApiShipCategory.vautour,
+        ApiShipCategory.béarn,
       ]
       if (!shipCategoryCount([ships[0]], cats)) {
         return false
@@ -7441,7 +7444,10 @@ register(
         ApiShipCategory.richelieu,
         ApiShipCategory.commandantTeste,
         ApiShipCategory.la_galissonniere,
-        ApiShipCategory.mogador
+        ApiShipCategory.mogador,
+        ApiShipCategory.algérie,
+        ApiShipCategory.vautour,
+        ApiShipCategory.béarn,
       ]
       return shipCategoryCount(ships, cats) >= 3
     }

--- a/src/common/kcquest.ts
+++ b/src/common/kcquest.ts
@@ -15285,7 +15285,11 @@ register(
       { id: 25 }
     ]
     static getCondition(svdata: SvData): DestroyItemCondition {
-      const ids = [svdata.shipMstIds(911), svdata.shipMstIds(488), 633].flat()
+      const ids = [
+        svdata.shipMstIds(911), // yamato kaini
+        svdata.shipMstIds(488), // yura kaini
+        svdata.shipMstIds(663), // yahagi kaini
+      ].flat()
       return {
         flagship_ids: ids,
         flagship_slotitem_ids: [238],

--- a/src/common/kcquest.ts
+++ b/src/common/kcquest.ts
@@ -7401,7 +7401,9 @@ register(
       }
 
       const msts = toShipMsts(svdata, ship_ids)
-      const shipIds1 = [
+      const shipIds = [
+        svdata.shipMstIds(1041), // hanaduki
+        svdata.shipMstIds(1044), // kiri
         svdata.shipMstIds(994), // kaya
         svdata.shipMstIds(992), // sugi
         svdata.shipMstIds(993), // kasi
@@ -7409,16 +7411,6 @@ register(
         svdata.shipMstIds(16), // usio
         svdata.shipMstIds(35), // hibiki
       ].flat()
-      // 6月
-      const shipIdsMonth6 = [
-        svdata.shipMstIds(41), // hatusimo
-        svdata.shipMstIds(20), // yukikaze
-        svdata.shipMstIds(533), // fuyutuki
-        svdata.shipMstIds(532), // sudutuki
-      ].flat()
-
-      const shipIds = [...shipIds1]
-      shipIds.push(...shipIdsMonth6)
       return shipCount(msts, shipIds) >= 5
     }
   }

--- a/src/common/kcs.ts
+++ b/src/common/kcs.ts
@@ -7861,7 +7861,7 @@ export interface ApiMap {
   readonly api_color_no: number
   readonly api_event_id: ApiEventId
   readonly api_event_kind: ApiEventKind
-  readonly api_next: number
+  readonly api_next: number  // 行き止まりの場合、0
   readonly api_bosscell_no: number
   readonly api_bosscomp: number
   readonly api_airsearch: ApiAirSearch
@@ -7902,6 +7902,18 @@ export interface ApiMapNext extends ApiMap {
   readonly api_get_eo_rate?: number
   readonly api_itemget_eo_result?: ApiItemGetEo
   readonly api_m1?: number // 2026夏イベでのE1H到達でのマップ変化で4が設定
+}
+
+const ApiRecoveryType = {
+  none: '0', // 選択無し
+  repair: '1', // 修理要員
+  megami: '2', // 女神
+} as const
+export type ApiRecoveryType = (typeof ApiRecoveryType)[keyof typeof ApiRecoveryType]
+
+interface ApiMapNextParam {
+  readonly api_verno: string
+  readonly api_recovery_type: ApiRecoveryType
 }
 
 export const ApiItemGetUseMst = {

--- a/src/common/kcs.ts
+++ b/src/common/kcs.ts
@@ -248,6 +248,10 @@ export const ApiShipCategory = {
   courageous_kubo: 135, // Courageous型(Glorious 空母)
   reitousen: 136, // 冷凍船
   thonburi: 137, // Thonburi型
+  algérie: 138, // Algérie型
+  vautour: 139, // Vautour型
+  visby: 140, // Visby型
+  béarn: 141, // Béarn型
 } as const
 export type ApiShipCategory = (typeof ApiShipCategory)[keyof typeof ApiShipCategory]
 

--- a/src/common/kcsetc.ts
+++ b/src/common/kcsetc.ts
@@ -4229,7 +4229,7 @@ export const ShipEtcs: ShipEtc[] = [
   {
     api_id: 1036,
     api_sakuteki: [NaN, 84],
-    api_kaihi: [NaN, 65],
+    api_kaihi: [33, 65],
   },
   {
     api_id: 1040,
@@ -4278,13 +4278,13 @@ export const ShipEtcs: ShipEtc[] = [
   },
   {
     api_id: 1060,
-    api_sakuteki: [NaN, NaN],
-    api_kaihi: [NaN, NaN],
+    api_sakuteki: [30, 68],
+    api_kaihi: [27, 48],
   },
   {
     api_id: 1061,
-    api_sakuteki: [NaN, NaN],
-    api_kaihi: [NaN, NaN],
+    api_sakuteki: [NaN, 80],
+    api_kaihi: [NaN, 55],
   },
   {
     api_id: 1062,
@@ -4298,13 +4298,13 @@ export const ShipEtcs: ShipEtc[] = [
   },
   {
     api_id: 1067,
-    api_sakuteki: [NaN, NaN],
-    api_kaihi: [NaN, NaN],
+    api_sakuteki: [9, 42],
+    api_kaihi: [54, 99],
   },
   {
     api_id: 1070,
-    api_sakuteki: [NaN, NaN],
-    api_kaihi: [NaN, NaN],
+    api_sakuteki: [17, 38],
+    api_kaihi: [15, 35],
   },
   {
     api_id: 1496,

--- a/src/common/state.ts
+++ b/src/common/state.ts
@@ -2,6 +2,7 @@ export class GameState {
   public record_ready: 'not_initialized' | 'in_initialize' | 'initialized' = 'not_initialized'
   public recording_state: RecordingState = 'inactive'
   public muted: boolean = false
+  public ctrl_pressed: boolean = false
 }
 
 export class AppState {

--- a/src/main/kcbrowser.ts
+++ b/src/main/kcbrowser.ts
@@ -17,6 +17,7 @@ import {
   MenuItem,
   Menu,
   Display,
+  Input,
 } from 'electron'
 import { autoUpdater } from 'electron-updater'
 import { is } from '@electron-toolkit/utils'
@@ -448,6 +449,17 @@ export class KcApp {
         webPreferences.preload = path.join(getMainDir(), '../preload/xhr-hook.js')
       }
     })
+
+    // 轟沈防止でCTRLキー押下状態を検知するため、webviewのbefore-input-eventを監視する(game webview側)
+    this.main_window.webContents.on('did-attach-webview', (_event, webContents: WebContents) => {
+      debug('did-attach-webview')
+      webContents.on('before-input-event', (_event, input) => this.onBeforeInputEvent(input))
+    })
+
+    // 轟沈防止でCTRLキー押下状態を検知するため、webviewのbefore-input-eventを監視する(main webcontents側)
+    // フォーカスロストはmain webcontents側でのみ検知できる
+    this.main_window.webContents.on('before-input-event', (_event, input) => this.onBeforeInputEvent(input))
+    this.main_window.webContents.on('blur', () => this.onMainWindowBlur())
 
     if (Env.isDevelopment) {
       this.main_window.webContents.openDevTools()
@@ -962,7 +974,7 @@ export class KcApp {
    * @param webContents
    */
   private onWebContentsCreated(_event: Event, webContents: WebContents): void {
-    debug('onWebContentsCreated') //, event, webContents);
+    debug('onWebContentsCreated', _event, 'url:', webContents.getURL());
 
     const didCreateWindowHandler = (window: BrowserWindow, detail: DidCreateWindowDetails) => 
       this.onDidCreateWindow(window, detail, webContents)
@@ -974,6 +986,63 @@ export class KcApp {
     webContents.once('destroyed', () => {
       webContents.removeListener('did-create-window', didCreateWindowHandler)
     })
+  }
+
+  /**
+   * 
+   */
+  private get isMainWindowDestroyed(): boolean {
+    const mainWindow = this.main_window
+    if (!mainWindow || mainWindow.isDestroyed()) {
+      return true
+    }
+
+    const webContents = mainWindow.webContents
+    if (!webContents || webContents.isDestroyed()) {
+      return true
+    }
+
+    return false
+  }
+
+  /**
+   * キー入力イベント処理
+   * CTRLキー押下で轟沈防止画面クリックを可とするためにgame側レンダラに通知する
+   * 
+   * @param input 
+   */
+  private onBeforeInputEvent(input: Input): void {
+    if (input.key === 'Control') {
+
+      if (this.isMainWindowDestroyed) {
+        debug('main window destroyed, ignore ctrl key event')
+        return
+      }
+
+      if (input.type === 'keyDown') {
+        debug('ctrl pressed')
+        this.main_window.webContents.send(GameChannel.set_ctrl_state, true)
+      }
+      
+      if (input.type === 'keyUp') {
+        debug('ctrl released')
+        this.main_window.webContents.send(GameChannel.set_ctrl_state, false)
+      }
+    }
+  }
+
+  /**
+   * フォーカスロストイベント処理
+   * CTRLキー状態をgame側レンダラに通知する
+   */
+  private onMainWindowBlur(): void {
+    const isDestroyed = this.isMainWindowDestroyed
+    debug('main window blur. isDestroyed:', isDestroyed)
+    if (isDestroyed) {
+      return
+    }
+
+    this.main_window.webContents.send(GameChannel.set_ctrl_state, false)
   }
 
   /**

--- a/src/renderer/src/assets/img/warning.svg
+++ b/src/renderer/src/assets/img/warning.svg
@@ -1,0 +1,39 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 56" role="img" aria-label="warning">
+  <defs>
+    <linearGradient id="warningFill" x1="32" y1="4" x2="32" y2="53" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#ffffff"/>
+      <stop offset="1" stop-color="#ffd8cf"/>
+    </linearGradient>
+  </defs>
+
+  <path
+    d="M32 3 62 53H2L32 3Z"
+    fill="url(#warningFill)"
+    stroke="#ffffff"
+    stroke-width="4"
+    stroke-linejoin="round"
+  />
+  <path
+    d="M32 3 62 53H2L32 3Z"
+    fill="none"
+    stroke="#ffb3a3"
+    stroke-width="2"
+    stroke-linejoin="round"
+    opacity="0.9"
+  />
+
+  <rect
+    x="28"
+    y="17"
+    width="8"
+    height="22"
+    rx="2"
+    fill="#a80000"
+  />
+  <circle
+    cx="32"
+    cy="46"
+    r="4"
+    fill="#a80000"
+  />
+</svg>

--- a/src/renderer/src/assets/main.scss
+++ b/src/renderer/src/assets/main.scss
@@ -94,9 +94,294 @@ body {
 }
 
 .game-container {
+  position: relative;
   width: 100%;
   //height: calc( 100% - 20px );
   height: calc(100% - 0px);
+
+  .taiha-overlay {
+    position: absolute;
+    inset: 0;
+    z-index: 10;
+    pointer-events: none;
+  }
+
+  //$waring-text-color: #FCEBE6;
+  $waring-text-color: #F9DBCF;
+  .taiha-warning-banner {
+    position: absolute;
+    left: 50%;
+    top: 7%;
+    transform: translateX(-50%);
+    z-index: 20;
+
+    width: 46%;
+    min-height: 52px;
+    padding: 7px 16px 8px;
+
+    box-sizing: border-box;
+    border: 2px solid #ff6b4a;
+    border-radius: 6px;
+
+    background: linear-gradient(
+      180deg,
+      rgba(166, 24, 16, 0.96),
+      rgba(103, 8, 6, 0.96)
+    );
+
+    box-shadow:
+      inset 0 1px 0 rgba(255, 255, 255, 0.2),
+      0 2px 8px rgba(0, 0, 0, 0.45);
+
+    color: $waring-text-color;
+    text-align: center;
+    text-shadow: 1px 1px 2px #000;
+    user-select: none;
+    pointer-events: none;
+
+    svg {
+      display: block;
+      $size: 28px;
+      width: $size;
+      height: $size;
+      flex: 0 0 auto;
+      fill: $waring-text-color;
+
+      filter:
+        drop-shadow(1px 1px 1px rgba(0, 0, 0, 0.7));
+    }
+
+    &.slide-effect-enter-from,
+    &.slide-effect-leave-to {
+      opacity: 0;
+      transform: translateX(-50%) translateY(10px);
+    }
+    &.slide-effect-enter-to,
+    &.slide-effect-leave-from {
+      opacity: 1;
+      transform: translateX(-50%) translateY(0px);
+    }
+    &.slide-effect-enter-active,
+    &.slide-effect-leave-active {
+      transition-property: transform, opacity;
+      transition-duration: 0.5s;
+      transition-delay: 0s;
+      transition-timing-function: ease;
+      will-change: transform, opacity;
+    }
+  }
+
+  .banner-title {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 5px;
+
+    font-size: 20px;
+    font-weight: 700;
+    line-height: 1.2;
+    margin-bottom: 4px;
+  }
+
+  .banner-text {
+    color: #ffe6a3;
+    font-size: 15px;
+    line-height: 1.3;
+    svg {
+      transform: translateY(1px);
+      display: inline-block;
+      $size: 16px;
+      width: $size;
+      height: $size;
+      flex: 0 0 auto;
+    }
+  }
+
+  .taiha-info {
+    white-space: nowrap;
+  }
+
+  .button-cover-shield {
+    position: absolute;
+    inset: 0;
+    width: 100%;
+    height: 100%;
+    display: block;
+    overflow: visible;
+
+    &.is-guard-hit {
+      .shield-fill {
+        animation: cyber-shield-fill-hit 0.55s ease-out;
+      }
+      .shield-border-outer {
+        animation: cyber-shield-border-hit 0.55s ease-out;
+      }
+      .shield-border-inner {
+        animation: cyber-shield-inner-hit 0.55s ease-out;
+      }
+    }
+  }
+
+  .shield-fill {
+    fill: rgba(80, 220, 255, 0.04);
+    fill: rgba(80, 220, 255, 0.04);
+  }
+
+  .shield-border-outer {
+    fill: none;
+    stroke: rgba(170, 245, 255, 0.52);
+    stroke: rgba(170, 245, 255, 0.10);
+    stroke-width: 2.5;
+    stroke-linejoin: round;
+  }
+
+  .shield-border-inner {
+    fill: none;
+    stroke: rgba(90, 220, 255, 0.25);
+    stroke: rgba(90, 220, 255, 0.05);
+    stroke-width: 1;
+    stroke-linejoin: round;
+  }
+
+  .block-shield-toggle {
+    position: absolute;
+    left: calc(50% + 23% + 12px);
+    top: 10.5%;
+    z-index: 21;
+
+    width: 137px;
+    //min-width: 135px;
+    .switch-text {
+      display: inline-block;
+      min-width: 78px;
+      text-align: left;
+    }
+    --bulma-control-padding-horizontal: 0px;
+
+    height: 32px;
+    padding: 0 10px;
+
+    box-sizing: border-box;
+    border: 1px solid #ff6b4a;
+    border-radius: 4px;
+
+    background: rgba(110, 18, 12, 0.98);
+    &:hover {
+      background: rgba(126, 26, 18, 0.98);
+    }
+
+    color: #ffe6a3;
+    font-size: 13px;
+    font-weight: 700;
+    text-shadow: 1px 1px 2px #000;
+    cursor: pointer;
+    pointer-events: auto;
+
+    &.slide-effect-enter-from,
+    &.slide-effect-leave-to {
+      opacity: 0;
+      transform: translateY(10px);
+    }
+    &.slide-effect-enter-to,
+    &.slide-effect-leave-from {
+      opacity: 1;
+      transform: translateY(0px);
+    }
+    &.slide-effect-enter-active,
+    &.slide-effect-leave-active {
+      transition-property: transform, opacity;
+      transition-duration: 0.5s;
+      transition-delay: 0s;
+      transition-timing-function: ease;
+      will-change: transform, opacity;
+    }
+  }
+  @at-root {
+    @keyframes cyber-shield-fill-hit {
+      0% {
+        fill: rgba(80, 220, 255, 0.04);
+      }
+
+      20% {
+        // fill: rgba(80, 220, 255, 0.28);
+        fill: rgba(80, 220, 255, 0.48);
+      }
+
+      100% {
+        fill: rgba(80, 220, 255, 0.04);
+      }
+    }
+
+    @keyframes cyber-shield-border-hit {
+      0% {
+        stroke: rgba(170, 245, 255, 0.52);
+        stroke-width: 2.5;
+        filter: none;
+      }
+
+      20% {
+        stroke: rgba(220, 255, 255, 0.98);
+        stroke-width: 2.8;
+        stroke-width: 3.0;
+        filter: url(#shieldCyanGlow);
+      }
+
+      100% {
+        stroke: rgba(170, 245, 255, 0.52);
+        stroke-width: 2.5;
+        filter: none;
+      }
+    }
+
+    @keyframes cyber-shield-inner-hit {
+      0% {
+        stroke: rgba(90, 220, 255, 0.25);
+      }
+
+      20% {
+        stroke: rgba(120, 255, 255, 0.85);
+      }
+
+      100% {
+        stroke: rgba(90, 220, 255, 0.25);
+      }
+    }
+  }
+
+  .button-cover {
+    position: absolute;
+    user-select: none;
+
+    opacity: 0;
+    &:hover, &.is-guard-hit {
+      opacity: 1;
+    }
+    transition: opacity 0.15s ease;
+
+    // ただの進撃ボタンの場合
+    left: 23%;
+    top: 41%;
+    width: 25%;
+    height: 25%;
+
+    &.is-flagship {
+      // 旗艦の場合(修理と女神ボタンをブロック)
+      left: 14.5%;
+      top: 20%;
+      width: 42%;
+      height: 76%;
+    }
+
+    pointer-events: auto;
+    cursor: not-allowed;
+
+    svg {
+      width: 100%;
+      height: 100%;
+    }
+
+  }
+
 }
 
 .assist-container {

--- a/src/renderer/src/components/Game.vue
+++ b/src/renderer/src/components/Game.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, onMounted, watch, onUnmounted } from 'vue'
+import { ref, onMounted, watch, onUnmounted, computed } from 'vue'
 // webview
 // https://www.electronjs.org/ja/docs/latest/api/webview-tag
 import { WebviewTag, DidFrameFinishLoadEvent, LoadCommitEvent, IpcRendererEvent } from 'electron'
@@ -9,6 +9,11 @@ import { Const } from '@common/const'
 import { gameState } from '@renderer/store/gamestate'
 import { EnvRenderer } from '@renderer/common/env-renderer'
 import { MainRendererState } from '@renderer/store/renderer_state'
+import * as kcs_stuff from '@renderer/stuff/kcs_stuff'
+import WarningIcon from '@assets/img/warning.svg'
+import { ApiCallback } from '@common/kcs'
+import { Api } from '@common/kcsapi'
+import { svdata } from '@renderer/store/svdata'
 const ipcRenderer = window.electron.ipcRenderer
 const el = ref<HTMLElement | null>(null)
 
@@ -19,6 +24,26 @@ const DEBUG = 0;
 const debug = (...args: any[]) => {
   if (DEBUG) console.debug("[game webview]", ...args);
 };
+
+/////////////////////////////////////////////////////////////////////////////////////
+// 大破進撃防止関連
+let cb_port = 0;
+let cb_battle_result = 0;
+let cb_combined_battle_result = 0;
+let cb_map_next = 0;
+const taihaSingekiResult = ref<kcs_stuff.CheckTaihaSingekiResult | null>(null)
+let blockShieldVisibleTimer: ReturnType<typeof setTimeout> | null = null
+const isBlockShieldEnabled = ref<boolean>(true)
+
+// アニメーション完了後に要素を削除するための判定に使用
+const isTaihaWarningInAnimation = ref(false)
+
+const clearBlockShieldVisibleTimer = () => {
+  if (blockShieldVisibleTimer) {
+    clearTimeout(blockShieldVisibleTimer)
+    blockShieldVisibleTimer = null
+  }
+}
 
 /////////////////////////////////////////////////////////////////////////////////////
 // 
@@ -88,6 +113,19 @@ onMounted(() => {
   }
 
   ipcRenderer.on(GameChannel.set_zoom_factor, setZoomFactor)
+
+  // 大破進撃防止関連
+  cb_port = ApiCallback.set([Api.PORT_PORT, () => onPort()])
+  cb_battle_result = ApiCallback.set(
+    [Api.REQ_SORTIE_BATTLERESULT, () => onBattleResult()]
+  )
+  cb_combined_battle_result = ApiCallback.set(
+    [Api.REQ_COMBINED_BATTLE_BATTLERESULT, () => onBattleResult()]
+  )
+  cb_map_next = ApiCallback.set(
+    [Api.REQ_MAP_NEXT, () => onMapNext()]
+  )
+
   debug('game mounted <<')
 })
 
@@ -104,6 +142,25 @@ onUnmounted(() => {
     webview.removeEventListener('media-started-playing', mediaStartedPlaying)
     webview.removeEventListener('media-paused', mediaPaused)
   }
+
+  if (cb_port) {
+    ApiCallback.unset(cb_port)
+    cb_port = 0
+  }
+  if (cb_battle_result) {
+    ApiCallback.unset(cb_battle_result)
+    cb_battle_result = 0
+  }
+  if (cb_combined_battle_result) {
+    ApiCallback.unset(cb_combined_battle_result)
+    cb_combined_battle_result = 0
+  }
+  if (cb_map_next) {
+    ApiCallback.unset(cb_map_next)
+    cb_map_next = 0
+  }
+  clearBlockShieldVisibleTimer()
+
   debug('game unmounted <<')
 })
 
@@ -264,6 +321,164 @@ defineExpose({
   getWebview,
   setMute
 })
+
+/////////////////////////////////////////////////////////////////////////////////////
+// 大破進撃関連
+function onPort(): void {
+  debug('onPort')
+  taihaSingekiResult.value = null
+  isBlockShieldEnabled.value = true
+  isTaihaWarningInAnimation.value = false
+  clearBlockShieldVisibleTimer()
+  gameState.ctrl_pressed = false
+}
+
+function onBattleResult(): void {
+
+  clearBlockShieldVisibleTimer()
+  isTaihaWarningInAnimation.value = false
+
+  // todo
+  // 大破進撃防止の判定は、艦隊HP更新後に行う必要があることの改善
+  // 艦隊HP更新はcallback呼び出し後に行われることからsettimeoutで遅延判定する
+  setTimeout(() => {
+    const result = kcs_stuff.checkTaihaSingeki()
+    debug('onBattleResult', result)
+
+    if (! result.isTaihaSingeki) {
+      debug('onBattleResult: no taiha singeki')
+      taihaSingekiResult.value = null
+      isTaihaWarningInAnimation.value = false
+      return
+    }
+
+    // 大破判定となった場合、戦闘結果画面が表示される約8秒後に表示する
+    const delaySec = 8000;
+    blockShieldVisibleTimer = setTimeout(() => {
+      taihaSingekiResult.value = result
+      isTaihaWarningInAnimation.value = true
+      blockShieldVisibleTimer = null
+    }, delaySec)
+
+  }, 0)
+}
+
+function onMapNext(): void {
+  debug('onMapNext')
+  taihaSingekiResult.value = null
+  isBlockShieldEnabled.value = true
+  gameState.ctrl_pressed = false
+}
+
+const isTaihaAdvanceBlockerVisible = computed<boolean>(() => {
+  const result = taihaSingekiResult.value
+  if (!result) {
+    debug('isTaihaAdvanceBlockerVisible: no result')
+    return false
+  }
+  debug('isTaihaAdvanceBlockerVisible: result', result)
+  return result.isTaihaSingeki
+})
+
+type TaihaShipInfo = {
+  // Lv.xx艦名(修理,女神)
+  // Lv.xx艦名(ダメコンなし)
+  shipText: string
+  dameconText: string
+  noDamageControl: boolean
+}
+
+const taihaShipInfos = computed<TaihaShipInfo[]>(() => {
+  const result = taihaSingekiResult.value
+  if (!result || !result.isTaihaSingeki) {
+    debug('taihaShipInfos: no result')
+    return []
+  }
+  return result.infos.map((info) => {
+    let dameconTexts: string[] = []
+    if (info.equips.includes(kcs_stuff.EquipType.flagship_megami) ||
+        info.equips.includes(kcs_stuff.EquipType.megami)) {
+      dameconTexts.push('女神')
+    }
+    if (info.equips.includes(kcs_stuff.EquipType.flagship_repair) ||
+        info.equips.includes(kcs_stuff.EquipType.repair)) {
+      dameconTexts.push('修理')
+    }
+    if (dameconTexts.length === 0) {
+      dameconTexts.push('ダメコンなし')
+    }
+
+    const api = info.api_ship
+    const mst = svdata.mstShip(api.api_ship_id)
+    const shipText = `Lv.${api.api_lv}${mst?.api_name ?? ''}`
+    const dameconText = dameconTexts.join(',')
+
+    return {
+      shipText,
+      dameconText,
+      noDamageControl: !info.equips.length
+    }
+  })
+})
+
+const isFlagshipTaiha = computed<boolean>(() => {
+  const result = taihaSingekiResult.value
+  if (!result || !result.isTaihaSingeki) {
+    debug('isFlagshipTaiha: no result')
+    return false
+  }
+
+  return result.infos.some((info) => {
+    const equips = info.equips
+    return equips.includes(kcs_stuff.EquipType.flagship_megami) ||
+           equips.includes(kcs_stuff.EquipType.flagship_repair)
+  })
+})
+
+const isBlockShieldVisible = computed<boolean>(() => {
+
+  // Ctrlキー押下時ならシールド無効
+  if (gameState.ctrl_pressed) {
+    debug('isBlockShieldVisible: ctrl pressed, shield hidden')
+    return false
+  }
+
+  debug('isBlockShieldVisible: shield visible', isBlockShieldEnabled.value)
+  return isBlockShieldEnabled.value
+})
+
+const isGuardHit = ref(false)
+
+const onButtonCoverClick = (_event: MouseEvent): void => {
+
+  // シールドアニメーション表示開始
+  isGuardHit.value = false
+  requestAnimationFrame(() => {
+    isGuardHit.value = true
+  })
+  setTimeout(() => {
+    isGuardHit.value = false
+  }, 450)
+}
+
+// 全体のオーバレイはアニメーション完了で要素を削除する
+const isTaihaOverlayVisible = computed<boolean>(() => {
+  debug('isTaihaOverlayVisible',
+  'isTaihaAdvanceBlockerVisible:', isTaihaAdvanceBlockerVisible.value, 
+  'isTaihaWarningInAnimation:', isTaihaWarningInAnimation.value)
+  
+  if(isTaihaAdvanceBlockerVisible.value) {
+    return true
+  }
+
+  return isTaihaWarningInAnimation.value
+})
+
+const onTaihaWarningAfterLeave = (): void => {
+  debug('onTaihaWarningAfterLeave')
+  isTaihaWarningInAnimation.value = false
+}
+
 </script>
 <template>
   <div class="game-container" ref="el">
@@ -277,5 +492,83 @@ defineExpose({
       nodeIntegrationInSubFrames="true"
       webPreferences="contextIsolation=no, sandbox=no"
     ></webview>
+
+    <div
+      v-if="isTaihaOverlayVisible"
+      class="taiha-overlay"
+    >
+      <transition name="slide-effect" appear @after-leave="onTaihaWarningAfterLeave">
+        <div 
+          v-if="isTaihaAdvanceBlockerVisible"
+          class="taiha-warning-banner">
+          <div class="banner-title"><WarningIcon />大破艦を検知しました</div>
+          <div class="banner-text">
+            轟沈防止で進撃操作を制限しています。シールドOFFにより操作可能です。
+          </div>
+          <div class="banner-text">
+            大破艦：<template v-for="(info, index) in taihaShipInfos" 
+              :key="`${index}-${info.shipText}-${info.dameconText}`"><span 
+              class="taiha-info">{{ info.shipText }}(<WarningIcon v-if="info.noDamageControl" />{{ info.dameconText }})</span><template v-if="index < taihaShipInfos.length - 1">, </template>
+            </template>
+          </div>
+        </div>
+      </transition>
+
+      <transition name="slide-effect" appear>
+        <b-switch
+          v-if="isTaihaAdvanceBlockerVisible"
+          v-model="isBlockShieldEnabled"
+          type="is-danger"
+          class="block-shield-toggle"
+          :left-label="true"
+        ><span class="switch-text">{{ isBlockShieldEnabled ? 'シールドON' : 'シールドOFF' }}</span></b-switch>
+      </transition>
+
+      <div class="button-cover" 
+        v-if="isBlockShieldVisible"
+        title="大破進撃防止" 
+        :class="{ 'is-flagship': isFlagshipTaiha }"
+        @click.prevent.stop="onButtonCoverClick">
+        <svg
+          class="button-cover-shield"
+          :class="{ 'is-guard-hit': isGuardHit }"
+          viewBox="0 0 220 120"
+          preserveAspectRatio="none"
+          aria-hidden="true"
+        >
+          <defs>
+            <filter id="shieldCyanGlow" x="-40%" y="-40%" width="180%" height="180%">
+              <feGaussianBlur stdDeviation="4" result="blur" />
+              <feFlood flood-color="#56f6ff" flood-opacity="0.85" result="glowColor" />
+              <feComposite in="glowColor" in2="blur" operator="in" result="glow" />
+              <feMerge>
+                <feMergeNode in="glow" />
+                <feMergeNode in="SourceGraphic" />
+              </feMerge>
+            </filter>
+          </defs>
+
+          <polygon
+            class="shield-fill"
+            points="38,2 182,2 218,60 182,118 38,118 2,60"
+            vector-effect="non-scaling-stroke"
+          />
+
+          <polygon
+            class="shield-border-outer"
+            points="38,2 182,2 218,60 182,118 38,118 2,60"
+            vector-effect="non-scaling-stroke"
+          />
+
+          <polygon
+            class="shield-border-inner"
+            points="45,12 175,12 205,60 175,108 45,108 15,60"
+            vector-effect="non-scaling-stroke"
+          />
+        </svg>
+      </div>
+
+    </div>
+
   </div>
 </template>

--- a/src/renderer/src/main.ts
+++ b/src/renderer/src/main.ts
@@ -63,6 +63,11 @@ ipcRenderer.on(GameChannel.set_app_state, (_event, state: AppState) => {
   Object.assign(appState, state)
 })
 
+ipcRenderer.on(GameChannel.set_ctrl_state, (_event, pressed: boolean) => {
+  console.log(GameChannel.set_ctrl_state, pressed)
+  gameState.ctrl_pressed = pressed
+})
+
 //console.log('process env', process.env);
 
 console.log('rederder ready')

--- a/src/renderer/src/stuff/kcs_stuff.ts
+++ b/src/renderer/src/stuff/kcs_stuff.ts
@@ -1,6 +1,6 @@
 import { svdata } from "@renderer/store/svdata";
 import { mapInfo as storeMapInfo } from '@renderer/store/mapinfo'
-import { ApiGaugeType } from "@common/kcs";
+import { ApiDeck, ApiDeckPort, ApiDeckPortId, ApiGaugeType, ApiShip, KcsUtil, ShipHpState, SvData } from "@common/kcs";
 import { computed } from "vue";
 
 export function isGimmickFlagDetected() {
@@ -29,4 +29,174 @@ export function isShowYusou() {
     return storeMapInfo.api_map_info.some(mi => mi.api_gauge_type === ApiGaugeType.yusou)
   });
   return {computed: ret};
+}
+
+export type TaihaEquipInfo = {
+  api_ship: ApiShip
+  equips: EquipType[]
+}
+
+export type CheckTaihaSingekiResult =
+  | {
+      isTaihaSingeki: true
+      infos: TaihaEquipInfo[]
+    }
+  | {
+      isTaihaSingeki: false
+      infos?: never
+    }
+
+export const EquipType = {
+  flagship_repair: 'flagship_repair',
+  flagship_megami: 'flagship_megami',
+  repair: 'repair',
+  megami: 'megami',
+} as const
+export type EquipType  = (typeof EquipType)[keyof typeof EquipType]
+
+/**
+ * 
+ * @param svdata 
+ * @param ship 
+ * @param isFlagship 
+ * @returns 
+ */
+const getEquipType = (svdata: SvData, ship: ApiShip, isFlagship: boolean): EquipType[] => {
+
+  const addEquip = (slotitem_id: number, equips: EquipType[]): void => {
+    const slotitem = svdata.slotitem(slotitem_id)
+    if (slotitem) {
+
+      // 応急修理要員
+      if (slotitem.api_slotitem_id === 42) {
+        equips.push(isFlagship ? EquipType.flagship_repair : EquipType.repair)
+      }
+
+      // 女神
+      if (slotitem.api_slotitem_id === 43) {
+        equips.push(isFlagship ? EquipType.flagship_megami : EquipType.megami)
+      }
+    }
+
+  };
+
+  const equips: EquipType[] = ship.api_slot.reduce<EquipType[]>((acc, slotitem_id) => {
+    addEquip(slotitem_id, acc)
+    return acc
+  }, []);
+
+  if (ship.api_slot_ex > 0) {
+    addEquip(ship.api_slot_ex, equips)
+  }
+
+  return equips
+}
+
+/**
+ * 
+ * @param svdata 
+ * @param deck 
+ * @returns 
+ */
+type TaihaShip = {
+  index: number
+  api_ship: ApiShip
+}
+const filterTaihaShip = (svdata: SvData, deck: ApiDeckPort): TaihaShip[] => {
+
+  const ships = deck.api_ship
+  return ships.reduce<TaihaShip[]>((acc, ship_id, index) => {
+
+    // 連合艦隊第2旗艦は判定しない
+    if (
+      (deck.api_id === ApiDeckPortId.deck2st) && 
+      (0 === index) &&
+      svdata.isCombined
+    ) {
+      return acc
+    }
+
+    // 退避している場合は大破判定しない
+    if (svdata.isShipEscaped(deck, index)) {
+      return acc      
+    }
+
+    const api_ship = svdata.ship(ship_id)
+    if (!api_ship) {
+      return acc
+    }
+
+    if (KcsUtil.shipHpState(api_ship) == ShipHpState.taiha) {
+      acc.push({
+        index,
+        api_ship
+      })
+    }
+
+    return acc;
+  }, [])
+}
+
+/**
+ * 進撃前での大破艦が存在するかのチェック
+ * 
+ * @returns 
+ */
+export function checkTaihaSingeki(): CheckTaihaSingekiResult {
+
+  // 出撃中で判定する
+  if (!svdata.inMap) {
+    return { isTaihaSingeki: false }
+  }
+
+  // 出撃艦隊情報が無いとき判定しない
+  const battleDeck = svdata.battleDeck
+  if (!battleDeck) {
+    return { isTaihaSingeki: false }
+  }
+
+  // 行き止まりの場合は判定しない
+  const lastMap = svdata.lastMap
+  if (! lastMap) {
+    return { isTaihaSingeki: false }
+  }
+  if (! lastMap.api_next) {
+    return { isTaihaSingeki: false }
+  }
+
+  // 退避艦は除外し、大破艦が存在するか？
+  // 存在すれば大破進撃
+  const taihaShips = filterTaihaShip(svdata, battleDeck)
+
+  // 出撃が第一艦隊で連合艦隊の場合は第二艦隊も判定する
+  const taihaShips2: TaihaShip[] = []
+  if (battleDeck.api_id == ApiDeckPortId.deck1st && svdata.isCombined) {
+    const deck2 = svdata.deckPort(ApiDeckPortId.deck2st)
+    if (deck2) {
+      taihaShips2.push(...filterTaihaShip(svdata, deck2))
+    }
+  }
+
+  // 大破艦が存在する場合は、装備情報を返す
+  if (taihaShips.length || taihaShips2.length) {
+    const infos: TaihaEquipInfo[] = []
+    taihaShips.forEach(taihaShip => {
+      infos.push({
+        api_ship: taihaShip.api_ship,
+        equips: getEquipType(svdata, taihaShip.api_ship, 0 === taihaShip.index)
+      })
+    })
+    taihaShips2.forEach(taihaShip => {
+      infos.push({
+        api_ship: taihaShip.api_ship,
+        equips: getEquipType(svdata, taihaShip.api_ship, false)
+      })
+    })
+    return {
+      isTaihaSingeki: true,
+      infos
+    }
+  }
+
+  return { isTaihaSingeki: false }
 }


### PR DESCRIPTION
## Summary

- 大破進撃防止の警告表示と進撃ボタンシールドを追加
- Ctrlキー状態の検知とrendererへの通知を追加
- 大破艦・ダメコン装備状態の判定表示を追加
- 関連する任務・艦データを更新

## Impact

- 大破艦を検知した場合、進撃操作を制限する警告UIを表示します。
- シールドOFFまたはCtrlキー押下により操作可能とする設計です。

## Validation

- Codexで `dev...fix/minor-1.0.8` の差分レビューを実施しました。
- 自動テストは未実行です。